### PR TITLE
Updated Utils and added some tests.

### DIFF
--- a/Delphi.Mocks.Utils.pas
+++ b/Delphi.Mocks.Utils.pas
@@ -29,7 +29,6 @@ unit Delphi.Mocks.Utils;
 interface
 
 uses
-  Rtti,
   TypInfo;
 
 
@@ -39,20 +38,19 @@ function CheckInterfaceHasRTTI(const info : PTypeInfo) : boolean;
 implementation
 
 uses
-    SysUtils;
-
-
+  SysUtils,
+  IntfInfo;
 
 function CheckInterfaceHasRTTI(const info : PTypeInfo) : boolean;
 var
-  rType : TRttiType;
-  ctx : TRttiContext;
-  methods : TArray<TRttiMethod>;
+  IntfMetaData: TIntfMetaData;
 begin
-  ctx := TRttiContext.Create;
-  rType := ctx.GetType(info);
-  methods := rType.GetDeclaredMethods;
-  result := Length(methods) > 0;
+  try
+    GetIntfMetaData(info, IntfMetaData, True);
+  except
+    Exit(False);
+  end;
+  Exit(True);
 end;
 
 

--- a/Tests/Delphi.Mocks.Tests.dpr
+++ b/Tests/Delphi.Mocks.Tests.dpr
@@ -35,7 +35,8 @@ uses
   Delphi.Mocks.Tests.Expectations in 'Delphi.Mocks.Tests.Expectations.pas',
   Delphi.Mocks.Expectation in '..\Delphi.Mocks.Expectation.pas',
   Delphi.Mocks.ObjectProxy in '..\Delphi.Mocks.ObjectProxy.pas',
-  Delphi.Mocks.ProxyBase in '..\Delphi.Mocks.ProxyBase.pas';
+  Delphi.Mocks.ProxyBase in '..\Delphi.Mocks.ProxyBase.pas',
+  Delphi.Mocks.Utils.Tests in 'Delphi.Mocks.Utils.Tests.pas';
 
 {$R *.RES}
 

--- a/Tests/Delphi.Mocks.Utils.Tests.pas
+++ b/Tests/Delphi.Mocks.Utils.Tests.pas
@@ -1,0 +1,35 @@
+unit Delphi.Mocks.Utils.Tests;
+
+interface
+uses
+  TestFramework;
+type
+  TUtilsTests = class(TTestcase)
+  published
+    procedure CheckInterfaceHasRTTIWithoutRTTI;
+    procedure CheckInterfaceHasRTTIWithNonInterface;
+    procedure CheckInterfaceHasRTTIWithInterfaceRTTI;
+  end;
+implementation
+uses
+  Delphi.Mocks.Utils;
+{ TUtilsTests }
+
+procedure TUtilsTests.CheckInterfaceHasRTTIWithInterfaceRTTI;
+
+begin
+  CheckTrue(CheckInterfaceHasRTTI(TypeInfo(IInvokable)));
+end;
+
+procedure TUtilsTests.CheckInterfaceHasRTTIWithNonInterface;
+begin
+  CheckFalse(CheckInterfaceHasRTTI(TypeInfo(TObject)));
+end;
+
+procedure TUtilsTests.CheckInterfaceHasRTTIWithoutRTTI;
+begin
+  CheckFalse(CheckInterfaceHasRTTI(TypeInfo(IInterface)));
+end;
+initialization
+  RegisterTest(TUtilsTests.Suite);
+end.


### PR DESCRIPTION
Removed Delphi.Mocks.Utils dependency on the RTTI unit. It's sole function can use IntfInfo just as easily.
Added Tests/Delphi.Mocks.Utils.Tests to exercise CheckInterfaceHasRTTI with a few scenarios. They all pass in D2009 but without access to versions with the new RTTI I'm flying blind.
