### PR TITLE
Add CheckExpectations function to TMock to ease using Delphi-Mocks with DUnit

### DIFF
--- a/Delphi.Mocks.Interfaces.pas
+++ b/Delphi.Mocks.Interfaces.pas
@@ -117,6 +117,7 @@ type
   IVerify = interface
   ['{58C05610-4BDA-451E-9D61-17C6376C3B3F}']
     procedure Verify(const message : string = '');
+    function CheckExpectations: string;
   end;
 
 implementation

--- a/Delphi.Mocks.ProxyBase.pas
+++ b/Delphi.Mocks.ProxyBase.pas
@@ -83,6 +83,7 @@ type
 
     //IVerify
     procedure Verify(const message : string = '');
+    function CheckExpectations: string;
 
     function GetMethodData(const AMethodName : string) : IMethodData;overload;
 
@@ -223,6 +224,24 @@ begin
   FBetween[1] := b;
   result := TWhen<T>.Create(Self.Proxy);
 
+end;
+
+function TBaseProxy<T>.CheckExpectations: string;
+var
+  methodData : IMethodData;
+  report : string;
+begin
+  Result := '';
+  for methodData in FMethodData.Values do
+  begin
+    report := '';
+    if not methodData.Verify(report) then
+    begin
+      if Result <> '' then
+        Result := Result + #13#10;
+      Result := Result + report ;
+    end;
+  end;
 end;
 
 procedure TBaseProxy<T>.ClearSetupState;
@@ -419,26 +438,10 @@ end;
 
 procedure TBaseProxy<T>.Verify(const message: string);
 var
-  methodData : IMethodData;
-  report : string;
   msg : string;
-  result : boolean;
 begin
-  msg := '';
-  result := true;
-  for methodData in FMethodData.Values do
-  begin
-    report := '';
-    if not methodData.Verify(report) then
-    begin
-      result := false;
-      if msg <> '' then
-        msg := msg + #13#10;
-      msg := msg + report ;
-    end;
-
-  end;
-  if not result then
+  msg := CheckExpectations;
+  if msg <> '' then
     raise EMockVerificationException.Create(message + #13#10 + msg);
 
 end;

--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -133,6 +133,7 @@ type
     function Setup : ISetup<T>;
     //Verify that our expectations were met.
     procedure Verify(const message : string = '');
+    function CheckExpectations: string;
     function Instance : T;
     function InstanceAsValue : TValue;
     class function Create: TMock<T>; static;
@@ -157,6 +158,17 @@ uses
   Delphi.Mocks.Interfaces,
   Delphi.Mocks.InterfaceProxy,
   Delphi.Mocks.ObjectProxy;
+
+function TMock<T>.CheckExpectations: string;
+var
+  su : ISetup<T>;
+  v : IVerify;
+begin
+  if Supports(FProxy.Setup,IVerify,v) then
+    Result := v.CheckExpectations
+  else
+    raise EMockException.Create('Could not cast Setup to IVerify interface!');
+end;
 
 class function TMock<T>.Create: TMock<T>;
 var


### PR DESCRIPTION
When using Delphi-Mocks in DUnit tests, I'd prefer to end the Test procedure with:

  CheckEqualsString('', fMockTest.CheckExpectations, 'Mock Test Expectations');

rather than:

  fMockTest.Verify;
  Check(True, 'dummy check to quieten DUnit');
