### PR TITLE
Fix for include file that isn't present.

### DIFF
--- a/Delphi.Mocks.WeakReference.pas
+++ b/Delphi.Mocks.WeakReference.pas
@@ -43,8 +43,6 @@ Delphi 2010 and has so far proven to be very reliable.
 
 *)
 
-{$I DUnitX.inc}
-
 interface
 
 type


### PR DESCRIPTION
Just a quick fix for the inclusion of DUnit include file that shouldn't be there. 
