### PR TITLE
Implement TMock<T>.Setup.BehaviorMustBeDefined - Issue #38

### DIFF
--- a/Delphi.Mocks.Proxy.pas
+++ b/Delphi.Mocks.Proxy.pas
@@ -480,7 +480,7 @@ begin
   if FMethodData.TryGetValue(methodName,Result) then
     exit;
 
-  Result := TMethodData.Create(AMethodName,FIsStubOnly);
+  Result := TMethodData.Create(AMethodName,FIsStubOnly, FBehaviorMustBeDefined);
   FMethodData.Add(methodName,Result);
 end;
 


### PR DESCRIPTION
Handling of the BehaviorMustBeDefined-Flag.
See: https://github.com/VSoftTechnologies/Delphi-Mocks/issues/38
