### PR TITLE
Fixed a bug, where an expectation like "....Between(0, 4)" failed

### DIFF
--- a/Delphi.Mocks.Expectation.pas
+++ b/Delphi.Mocks.Expectation.pas
@@ -54,6 +54,7 @@ type
     function GetExpectationMet : boolean;
     function Match(const Args : TArray<TValue>) : boolean;
     procedure RecordHit;
+    procedure CheckExpectationMet;
     function Report : string;
     function ArgsToString : string;
     procedure CopyArgs(const Args: TArray<TValue>);
@@ -86,6 +87,8 @@ type
 
     constructor CreateAfterWhen(const AMethodName : string; const AAfterMethodName : string;const Args : TArray<TValue>);
     constructor CreateAfter(const AMethodName : string; const AAfterMethodName : string);
+
+    procedure AfterConstruction; override;
   end;
 
 
@@ -96,6 +99,12 @@ uses
   Delphi.Mocks.Helpers;
 
 { TExpectation }
+
+procedure TExpectation.AfterConstruction;
+begin
+  inherited;
+  CheckExpectationMet;
+end;
 
 function TExpectation.ArgsToString: string;
 var
@@ -244,14 +253,12 @@ constructor TExpectation.CreateNever(const AMethodName : string) ;
 begin
   Create(AMethodName);
   FExpectationType := TExpectationType.Never;
-  FExpectationMet := True;
 end;
 
 constructor TExpectation.CreateNeverWhen(const AMethodName : string; const Args: TArray<TValue>);
 begin
   CreateWhen(AMethodName,Args);
   FExpectationType := TExpectationType.NeverWhen;
-  FExpectationMet := True;
 end;
 
 constructor TExpectation.CreateOnce(const AMethodName : string );
@@ -325,11 +332,16 @@ end;
 procedure TExpectation.RecordHit;
 begin
   Inc(FHitCount);
+  CheckExpectationMet;
+end;
+
+procedure TExpectation.CheckExpectationMet;
+begin
   case FExpectationType of
     Once,
     OnceWhen: FExpectationMet := FHitCount = 1;
     Never,
-    NeverWhen: FExpectationMet := False;
+    NeverWhen: FExpectationMet := FHitCount = 0;
     AtLeastOnce,
     AtLeastOnceWhen: FExpectationMet := FHitCount >= 1;
     AtLeast,


### PR DESCRIPTION
An expectation like "....Between(0, 4)" failed, because the ExpectationMet-Flag was only set when hitting a method (which isn't the case on a "zero hit method")
