### PR TITLE
Added possiblity to allow redefinition of behaviors

### DIFF
--- a/Delphi.Mocks.MethodData.pas
+++ b/Delphi.Mocks.MethodData.pas
@@ -38,6 +38,13 @@ uses
   Delphi.Mocks.Interfaces;
 
 type
+  TSetupMethodDataParameters = record
+    BehaviorMustBeDefined  : boolean;
+    AllowRedefineBehaviorDefinitions: boolean;
+    IsStub: boolean;
+    class function Create(const AIsStub: boolean; const ABehaviorMustBeDefined, AAllowRedefineBehaviorDefinitions: boolean): TSetupMethodDataParameters; static;
+  end;
+
   TMethodData = class(TInterfacedObject,IMethodData)
   private
     FTypeName      : string;
@@ -45,8 +52,7 @@ type
     FBehaviors      : TList<IBehavior>;
     FReturnDefault  : TValue;
     FExpectations   : TList<IExpectation>;
-    FIsStub         : boolean;
-    FBehaviorMustBeDefined: boolean;
+    FSetupParameters: TSetupMethodDataParameters;
   protected
 
     //Behaviors
@@ -89,7 +95,7 @@ type
 
     function Verify(var report : string) : boolean;
   public
-    constructor Create(const ATypeName : string; const AMethodName : string; const AIsStub : boolean; const ABehaviorMustBeDefined: boolean);
+    constructor Create(const ATypeName : string; const AMethodName : string; const ASetupParameters: TSetupMethodDataParameters);
     destructor Destroy;override;
   end;
 
@@ -109,15 +115,14 @@ uses
 { TMethodData }
 
 
-constructor TMethodData.Create(const ATypeName : string; const AMethodName : string; const AIsStub : boolean; const ABehaviorMustBeDefined: boolean);
+constructor TMethodData.Create(const ATypeName : string; const AMethodName : string; const ASetupParameters: TSetupMethodDataParameters);
 begin
   FTypeName := ATypeName;
   FMethodName := AMethodName;
   FBehaviors := TList<IBehavior>.Create;
   FExpectations := TList<IExpectation>.Create;
   FReturnDefault := TValue.Empty;
-  FBehaviorMustBeDefined := ABehaviorMustBeDefined;
-  FIsStub := AIsStub;
+  FSetupParameters := ASetupParameters;
 end;
 
 destructor TMethodData.Destroy;
@@ -132,8 +137,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation([TExpectationType.Exactly,TExpectationType.ExactlyWhen]);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation Exactly for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil)  AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation Exactly for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateExactly(FMethodName,times);
   FExpectations.Add(expectation);
 end;
@@ -144,8 +152,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation(TExpectationType.ExactlyWhen,Args);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation Exactly for method [%s] with args.', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation Exactly for method [%s] with args.', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateExactlyWhen(FMethodName,times,Args);
   FExpectations.Add(expectation);
 end;
@@ -260,8 +271,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation([TExpectationType.AtLeast,TExpectationType.AtLeastOnce,TExpectationType.AtLeastOnceWhen,TExpectationType.AtLeastWhen]);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation At Least for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation At Least for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateAtLeast(FMethodName,times);
   FExpectations.Add(expectation);
 end;
@@ -271,8 +285,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation([TExpectationType.AtLeast,TExpectationType.AtLeastOnce,TExpectationType.AtLeastOnceWhen,TExpectationType.AtLeastWhen]);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation At Least Once for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation At Least Once for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateAtLeastOnce(FMethodName);
   FExpectations.Add(expectation);
 end;
@@ -282,8 +299,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation(TExpectationType.AtLeastOnceWhen,Args);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation At Least Once When for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation At Least Once When for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateAtLeastOnceWhen(FMethodName,Args);
   FExpectations.Add(expectation);
 end;
@@ -293,8 +313,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation(TExpectationType.AtLeastWhen,Args);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation At Least When for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation At Least When for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateAtLeastWhen(FMethodName,times,Args);
   FExpectations.Add(expectation);
 end;
@@ -304,8 +327,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation([TExpectationType.AtMost,TExpectationType.AtMostWhen]);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation At Most for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation At Most for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateAtMost(FMethodName,times);
   FExpectations.Add(expectation);
 end;
@@ -316,8 +342,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation(TExpectationType.AtMostWhen,Args);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation At Most When for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation At Most When for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateAtMostWhen(FMethodName,times,Args);
   FExpectations.Add(expectation);
 end;
@@ -337,8 +366,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation([TExpectationType.Between,TExpectationType.BetweenWhen]);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation Between for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation Between for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateBetween(FMethodName,a,b);
   FExpectations.Add(expectation);
 end;
@@ -348,8 +380,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation(TExpectationType.BetweenWhen,Args);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation Between When for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation Between When for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateBetweenWhen(FMethodName,a,b,Args);
   FExpectations.Add(expectation);
 end;
@@ -361,8 +396,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation([TExpectationType.Never ,TExpectationType.NeverWhen]);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation Never for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation Never for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   
   expectation := TExpectation.CreateNever(FMethodName);
   FExpectations.Add(expectation);
@@ -373,8 +411,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation(TExpectationType.NeverWhen,Args);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation Never When for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation Never When for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateNeverWhen(FMethodName,Args);
   FExpectations.Add(expectation);
 end;
@@ -384,8 +425,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation([TExpectationType.Once,TExpectationType.OnceWhen]);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation Once for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation Once for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateOnce(FMethodName);
   FExpectations.Add(expectation);
 end;
@@ -395,8 +439,11 @@ var
   expectation : IExpectation;
 begin
   expectation := FindExpectation(TExpectationType.OnceWhen,Args);
-  if expectation <> nil then
-    raise EMockException.Create(Format('[%s] already defines Expectation Once When for method [%s]', [FTypeName, FMethodName]));
+  if (expectation <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockException.Create(Format('[%s] already defines Expectation Once When for method [%s]', [FTypeName, FMethodName]))
+  else if expectation <> nil then
+    FExpectations.Remove(expectation);
+
   expectation := TExpectation.CreateOnceWhen(FMethodName,Args);
   FExpectations.Add(expectation);
 end;
@@ -426,7 +473,7 @@ begin
   begin
     if (returnType <> nil) and (FReturnDefault.IsEmpty) then
     begin
-      if FIsStub then
+      if FSetupParameters.IsStub then
       begin
         //Stubs return default values.
         result := GetDefaultValue(returnType);
@@ -437,7 +484,7 @@ begin
         raise EMockException.Create(Format('[%s] has no default return value defined for method [%s]', [FTypeName, FMethodName]));
       end;
     end
-    else if FBehaviorMustBeDefined and (expectationHitCtr = 0) and (FReturnDefault.IsEmpty) then
+    else if FSetupParameters.BehaviorMustBeDefined and (expectationHitCtr = 0) and (FReturnDefault.IsEmpty) then
     begin
       //If we must have default behaviour defined, and there was nothing defined raise a mock exception.
       raise EMockException.Create(Format('[%s] has no behaviour or expectation defined for method [%s]', [FTypeName, FMethodName]));
@@ -478,8 +525,11 @@ var
   behavior : IBehavior;
 begin
   behavior := FindBehavior(TBehaviorType.WillExecute);
-  if behavior <> nil then
-    raise EMockSetupException.Create(Format('[%s] already defines WillExecute for method [%s]', [FTypeName, FMethodName]));
+  if (behavior <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions) then
+    raise EMockSetupException.Create(Format('[%s] already defines WillExecute for method [%s]', [FTypeName, FMethodName]))
+  else if behavior <> nil then
+    FBehaviors.Remove(behavior);
+
   behavior := TBehavior.CreateWillExecute(func);
   FBehaviors.Add(behavior);
 end;
@@ -489,8 +539,11 @@ var
   behavior : IBehavior;
 begin
   behavior := FindBehavior(TBehaviorType.WillExecuteWhen,Args);
-  if behavior <> nil then
-    raise EMockSetupException.Create(Format('[%s] already defines WillExecute When for method [%s]', [FTypeName, FMethodName]));
+  if (behavior <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockSetupException.Create(Format('[%s] already defines WillExecute When for method [%s]', [FTypeName, FMethodName]))
+  else if behavior <> nil then
+    FBehaviors.Remove(behavior);
+
   behavior := TBehavior.CreateWillExecuteWhen(Args, func);
   FBehaviors.Add(behavior);
 end;
@@ -500,8 +553,11 @@ var
   behavior : IBehavior;
 begin
   behavior := FindBehavior(TBehaviorType.WillRaiseAlways);
-  if behavior <> nil then
-    raise EMockSetupException.Create(Format('[%s] already defines Will Raise Always for method [%s]', [FTypeName, FMethodName]));
+  if (behavior <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockSetupException.Create(Format('[%s] already defines Will Raise Always for method [%s]', [FTypeName, FMethodName]))
+  else if behavior <> nil then
+    FBehaviors.Remove(behavior);
+
   behavior := TBehavior.CreateWillRaise(exceptionClass,message);
   FBehaviors.Add(behavior);
 end;
@@ -511,15 +567,18 @@ var
   behavior : IBehavior;
 begin
   behavior := FindBehavior(TBehaviorType.WillRaise,Args);
-  if behavior <> nil then
-    raise EMockSetupException.Create(Format('[%s] already defines Will Raise When for method [%s]', [FTypeName, FMethodName]));
+  if (behavior <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockSetupException.Create(Format('[%s] already defines Will Raise When for method [%s]', [FTypeName, FMethodName]))
+  else if behavior <> nil then
+    FBehaviors.Remove(behavior);
+
   behavior := TBehavior.CreateWillRaiseWhen(Args,exceptionClass,message);
   FBehaviors.Add(behavior);
 end;
 
 procedure TMethodData.WillReturnDefault(const returnValue: TValue);
 begin
-  if not FReturnDefault.IsEmpty then
+  if (not FReturnDefault.IsEmpty) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions) then
     raise EMockSetupException.Create(Format('[%s] already defines Will Return Default for method [%s]', [FTypeName, FMethodName]));
   FReturnDefault := returnValue;
 end;
@@ -529,10 +588,21 @@ var
   behavior : IBehavior;
 begin
   behavior := FindBehavior(TBehaviorType.WillReturn,Args);
-  if behavior <> nil then
-    raise EMockSetupException.Create(Format('[%s] already defines Will Return When for method [%s]', [FTypeName, FMethodName]));
+  if (behavior <> nil) AND (not FSetupParameters.AllowRedefineBehaviorDefinitions)  then
+    raise EMockSetupException.Create(Format('[%s] already defines Will Return When for method [%s]', [FTypeName, FMethodName]))
+  else if behavior <> nil then
+    FBehaviors.Remove(behavior);
+
   behavior := TBehavior.CreateWillReturnWhen(Args,returnValue);
   FBehaviors.Add(behavior);
+end;
+
+{ TSetupMethodDataParameters }
+class function TSetupMethodDataParameters.Create(const AIsStub: boolean; const ABehaviorMustBeDefined, AAllowRedefineBehaviorDefinitions: boolean): TSetupMethodDataParameters;
+begin
+  result.IsStub := AIsStub;
+  result.BehaviorMustBeDefined := ABehaviorMustBeDefined;
+  result.AllowRedefineBehaviorDefinitions := AAllowRedefineBehaviorDefinitions;
 end;
 
 end.

--- a/Delphi.Mocks.Proxy.pas
+++ b/Delphi.Mocks.Proxy.pas
@@ -61,6 +61,7 @@ type
 
     FMethodData             : TDictionary<string, IMethodData>;
     FBehaviorMustBeDefined  : Boolean;
+    FAllowRedefineBehaviorDefinitions  : Boolean;
     FSetupMode              : TSetupMode;
     //behavior setup
     FNextBehavior           : TBehaviorType;
@@ -119,6 +120,9 @@ type
     //ISetup<T>
     function GetBehaviorMustBeDefined : boolean;
     procedure SetBehaviorMustBeDefined(const value : boolean);
+    function GetAllowRedefineBehaviorDefinitions : boolean;
+    procedure SetAllowRedefineBehaviorDefinitions(const value : boolean);
+
     function Expect : IExpect<T>;
 
     {$Message 'TODO: Implement ISetup.Before and ISetup.After.'}
@@ -472,10 +476,17 @@ begin
   Result := FBehaviorMustBeDefined;
 end;
 
+function TProxy<T>.GetAllowRedefineBehaviorDefinitions : boolean;
+begin
+  result := FAllowRedefineBehaviorDefinitions;
+end;
+
+
 function TProxy<T>.GetMethodData(const AMethodName: string): IMethodData;
 var
   methodName : string;
   pInfo : PTypeInfo;
+  setupParams: TSetupMethodDataParameters;
 begin
   methodName := LowerCase(AMethodName);
   if FMethodData.TryGetValue(methodName,Result) then
@@ -483,7 +494,8 @@ begin
 
   pInfo := TypeInfo(T);
 
-  Result := TMethodData.Create(pInfo.Name, AMethodName, FIsStubOnly, FBehaviorMustBeDefined);
+  setupParams := TSetupMethodDataParameters.Create(FIsStubOnly, FBehaviorMustBeDefined, FAllowRedefineBehaviorDefinitions);
+  Result := TMethodData.Create(pInfo.Name, AMethodName, setupParams);
   FMethodData.Add(methodName,Result);
 end;
 
@@ -595,6 +607,12 @@ procedure TProxy<T>.SetBehaviorMustBeDefined(const value: boolean);
 begin
   FBehaviorMustBeDefined := value;
 end;
+
+procedure TProxy<T>.SetAllowRedefineBehaviorDefinitions(const value : boolean);
+begin
+  FAllowRedefineBehaviorDefinitions := value;
+end;
+
 
 procedure TProxy<T>.SetParentProxy(const AProxy : IProxy);
 begin

--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -86,6 +86,9 @@ type
     ['{3E6AD69A-11EA-47F1-B5C3-63F7B8C265B1}']
     function GetBehaviorMustBeDefined : boolean;
     procedure SetBehaviorMustBeDefined(const value : boolean);
+    function GetAllowRedefineBehaviorDefinitions : boolean;
+    procedure SetAllowRedefineBehaviorDefinitions(const value : boolean);
+
     //set the return value for a method when called with the parameters specified on the When
     function WillReturn(const value : TValue) : IWhen<T>;
 
@@ -107,6 +110,9 @@ type
 
     //If true, calls to methods for which we have not defined a behavior will cause verify to fail.
     property BehaviorMustBeDefined : boolean read GetBehaviorMustBeDefined write SetBehaviorMustBeDefined;
+
+    //If true, it is possible to overwrite a already defined behaviour.
+    property AllowRedefineBehaviorDefinitions: boolean read GetAllowRedefineBehaviorDefinitions write SetAllowRedefineBehaviorDefinitions;
   end;
 
   //We use the Setup to configure our expected behaviour rules and to verify

--- a/Tests/Delphi.Mocks.Tests.MethodData.pas
+++ b/Tests/Delphi.Mocks.Tests.MethodData.pas
@@ -13,6 +13,14 @@ type
   TTestMethodData = class(TTestCase)
   published
     procedure Expectation_Before_Verifies_To_True_When_Prior_Method_Called_Atleast_Once;
+
+    procedure AllowRedefineBehaviorDefinitions_IsTrue_RedefinedIsAllowed;
+    procedure AllowRedefineBehaviorDefinitions_IsFalse_ExceptionIsThrown_WhenRedefining;
+    procedure AllowRedefineBehaviorDefinitions_IsFalse_NoExceptionIsThrown_WhenAddingNormal;
+    procedure AllowRedefineBehaviorDefinitions_IsTrue_OldBehaviorIsDeleted;
+
+    procedure BehaviourMustBeDefined_IsFalse_AndBehaviourIsNotDefined_RaisesNoException;
+    procedure BehaviourMustBeDefined_IsTrue_AndBehaviourIsNotDefined_RaisesException;
   end;
 
 implementation
@@ -20,7 +28,7 @@ implementation
 uses
   Delphi.Mocks.Helpers,
   Delphi.Mocks.MethodData,
-  classes;
+  classes, System.TypInfo;
 
 
 { TTestMethodData }
@@ -29,5 +37,100 @@ procedure TTestMethodData.Expectation_Before_Verifies_To_True_When_Prior_Method_
 begin
   Check(False, 'Not implemented');
 end;
+
+procedure TTestMethodData.AllowRedefineBehaviorDefinitions_IsTrue_RedefinedIsAllowed;
+var
+  methodData  : IMethodData;
+  someValue1,
+  someValue2  : TValue;
+begin
+  someValue1 := TValue.From<Integer>(1);
+  someValue2 := TValue.From<Integer>(2);
+
+  methodData := TMethodData.Create('x', 'x', TSetupMethodDataParameters.Create(FALSE, False, TRUE));
+  methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue1);
+  methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue2);
+
+  // no exception is raised
+  CheckTrue(True);
+end;
+
+procedure TTestMethodData.AllowRedefineBehaviorDefinitions_IsFalse_ExceptionIsThrown_WhenRedefining;
+var
+  methodData  : IMethodData;
+  someValue1,
+  someValue2  : TValue;
+begin
+  someValue1 := TValue.From<Integer>(1);
+  someValue2 := TValue.From<Integer>(2);
+
+  methodData := TMethodData.Create('x', 'x', TSetupMethodDataParameters.Create(FALSE, FALSE, FALSE));
+  methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue1);
+
+  StartExpectingException(EMockException);
+  methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue2);
+  StopExpectingException;
+end;
+
+procedure TTestMethodData.AllowRedefineBehaviorDefinitions_IsFalse_NoExceptionIsThrown_WhenAddingNormal;
+var
+  methodData  : IMethodData;
+  someValue1,
+  someValue2  : TValue;
+begin
+  someValue1 := TValue.From<Integer>(1);
+  someValue2 := TValue.From<Integer>(2);
+  methodData := TMethodData.Create('x', 'x', TSetupMethodDataParameters.Create(FALSE, FALSE, FALSE));
+  methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue1);
+  methodData.WillReturnWhen(TArray<TValue>.Create(someValue2), someValue2);
+
+  CheckTrue(True);
+end;
+
+procedure TTestMethodData.AllowRedefineBehaviorDefinitions_IsTrue_OldBehaviorIsDeleted;
+var
+  methodData  : IMethodData;
+  someValue1,
+  someValue2  : TValue;
+  outValue    : TValue;
+begin
+  someValue1 := TValue.From<Integer>(1);
+  someValue2 := TValue.From<Integer>(2);
+  methodData := TMethodData.Create('x', 'x', TSetupMethodDataParameters.Create(TRUE, TRUE, TRUE));
+  methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue1);
+  methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue2);
+
+  methodData.RecordHit(TArray<TValue>.Create(someValue1), TrttiContext.Create.GetType(TypeInfo(integer)), outValue);
+
+  CheckEquals(someValue2.AsInteger, outValue.AsInteger );
+end;
+
+
+procedure TTestMethodData.BehaviourMustBeDefined_IsFalse_AndBehaviourIsNotDefined_RaisesNoException;
+var
+  methodData  : IMethodData;
+  someValue   : TValue;
+begin
+  methodData := TMethodData.Create('x', 'x', TSetupMethodDataParameters.Create(FALSE, FALSE, FALSE));
+  methodData.RecordHit(TArray<TValue>.Create(), nil, someValue);
+  // no exception should be raised
+  CheckTrue(True);
+end;
+
+procedure TTestMethodData.BehaviourMustBeDefined_IsTrue_AndBehaviourIsNotDefined_RaisesException;
+var
+  methodData  : IMethodData;
+  someValue   : TValue;
+begin
+  methodData := TMethodData.Create('x', 'x', TSetupMethodDataParameters.Create(FALSE, TRUE, FALSE));
+
+  StartExpectingException(EMockException);
+  methodData.RecordHit(TArray<TValue>.Create(), TRttiContext.Create.GetType(TypeInfo(Integer)), someValue);
+  StopExpectingException;
+end;
+
+initialization
+  TestFramework.RegisterTest(TTestMethodData.Suite);
+
 
 end.


### PR DESCRIPTION
If "myMock.Setup.AllowRedefinedBehaviorDefinitions" is set to true, behaviors with the same params gets replaced instead of throwing an exception.

I also added some unittests for "BehaviorMustBeDefined"-Flag and refactored the TMethodData-Constructor.
