### PR TITLE
show the arguments to an unexpected method call with no default retun…

### DIFF
--- a/Delphi.Mocks.Expectation.pas
+++ b/Delphi.Mocks.Expectation.pas
@@ -31,7 +31,8 @@ interface
 uses
   Rtti,
   Delphi.Mocks,
-  Delphi.Mocks.Interfaces;
+  Delphi.Mocks.Interfaces,
+  Delphi.Mocks.Utils;
 
 
 //disable warnings about c++ compatibility, since we don't intend to support it.
@@ -107,17 +108,8 @@ begin
 end;
 
 function TExpectation.ArgsToString: string;
-var
-  i : integer;
 begin
-  result := '( ';
-  for i := Low(FArgs) to High(FArgs) do
-  begin
-    if i > 0 then
-      result := result + ', ';
-    result := result + FArgs[i].ToString;
-  end;
-  result := result + ' )';
+  Result := Delphi.Mocks.Utils.ArgsToString(FArgs);
 end;
 
 procedure TExpectation.CopyArgs(const Args: TArray<TValue>);

--- a/Delphi.Mocks.MethodData.pas
+++ b/Delphi.Mocks.MethodData.pas
@@ -481,7 +481,8 @@ begin
       else
       begin
         //If it's not a stub then we say we didn't have a default return value
-        raise EMockException.Create(Format('[%s] has no default return value defined for method [%s]', [FTypeName, FMethodName]));
+        raise EMockException.Create(Format('[%s] has no default return value defined for method [%s] with args %s',
+             [FTypeName, FMethodName, Delphi.Mocks.Utils.ArgsToString(Args, 1)]));
       end;
     end
     else if FSetupParameters.BehaviorMustBeDefined and (expectationHitCtr = 0) and (FReturnDefault.IsEmpty) then

--- a/Delphi.Mocks.Utils.pas
+++ b/Delphi.Mocks.Utils.pas
@@ -39,6 +39,8 @@ function GetVirtualMethodCount(AClass: TClass): Integer;
 
 function GetDefaultValue(const rttiType : TRttiType) : TValue;
 
+function ArgsToString(const Args: TArray<TValue>; OffSet: Integer = 0): string;
+
 implementation
 
 uses
@@ -124,6 +126,18 @@ begin
   end;
 end;
 
-
+function ArgsToString(const Args: TArray<TValue>; OffSet: Integer = 0): string;
+var
+  i : integer;
+begin
+  result := EmptyStr;
+  for i := Low(Args) + OffSet to High(Args) do
+  begin
+    if (result <> EmptyStr) then
+      result := result + ', ';
+    result := result + Args[i].ToString;
+  end;
+  result := '( ' + result + ' )';
+end;
 
 end.

--- a/Tests/Delphi.Mocks.Tests.MethodData.pas
+++ b/Tests/Delphi.Mocks.Tests.MethodData.pas
@@ -10,6 +10,12 @@ uses
   Delphi.Mocks.Interfaces;
 
 type
+  {$M+}
+  ISimpleInterface = interface
+    function MissingArg(Value: Integer): Integer;
+  end;
+  {$M-}
+
   TTestMethodData = class(TTestCase)
   published
     procedure Expectation_Before_Verifies_To_True_When_Prior_Method_Called_Atleast_Once;
@@ -21,6 +27,8 @@ type
 
     procedure BehaviourMustBeDefined_IsFalse_AndBehaviourIsNotDefined_RaisesNoException;
     procedure BehaviourMustBeDefined_IsTrue_AndBehaviourIsNotDefined_RaisesException;
+
+    procedure RaiseExceptionWhenMissingArgsAndDontHaveDefaultValue;
   end;
 
 implementation
@@ -28,7 +36,7 @@ implementation
 uses
   Delphi.Mocks.Helpers,
   Delphi.Mocks.MethodData,
-  classes, System.TypInfo;
+  classes, System.TypInfo, StrUtils;
 
 
 { TTestMethodData }
@@ -36,6 +44,28 @@ uses
 procedure TTestMethodData.Expectation_Before_Verifies_To_True_When_Prior_Method_Called_Atleast_Once;
 begin
   Check(False, 'Not implemented');
+end;
+
+procedure TTestMethodData.RaiseExceptionWhenMissingArgsAndDontHaveDefaultValue;
+const
+  EXPECTED_ERROR_MESSAGE = 'method [MissingArg] with args ( 4 )';
+var
+  vMock: TMock<ISimpleInterface>;
+begin
+  vMock := TMock<ISimpleInterface>.Create;
+  vMock.Setup.Expect.Once.When.MissingArg(123);
+
+  try
+    vMock.Instance.MissingArg(4);
+    Fail('Do not raise Exception');
+  except
+    on E: Exception do
+    begin
+      CheckEquals(EMockException.ClassName, E.ClassName, 'Expect a MockException');
+      CheckTrue(ContainsText(E.Message, EXPECTED_ERROR_MESSAGE),
+                Format('Expect the string <%s> contains the substring <%s>',[E.Message, EXPECTED_ERROR_MESSAGE]));
+    end;
+  end;
 end;
 
 procedure TTestMethodData.AllowRedefineBehaviorDefinitions_IsTrue_RedefinedIsAllowed;

--- a/Tests/Delphi.Mocks.Tests.dpr
+++ b/Tests/Delphi.Mocks.Tests.dpr
@@ -50,7 +50,7 @@ uses
   Delphi.Mocks.Tests.ObjectProxy in 'Delphi.Mocks.Tests.ObjectProxy.pas',
   Delphi.Mocks.Examples.Objects in 'Delphi.Mocks.Examples.Objects.pas',
   Delphi.Mocks.ReturnTypePatch in '..\Delphi.Mocks.ReturnTypePatch.pas',
-  Delphi.Mocks.Tests.InterfaceProxy in 'Delphi.Mocks.Tests.InterfaceProxy.pas' {$R *.RES},
+  Delphi.Mocks.Tests.InterfaceProxy in 'Delphi.Mocks.Tests.InterfaceProxy.pas',
   VSoft.DUnit.XMLTestRunner in '..\DUnitXML\VSoft.DUnit.XMLTestRunner.pas',
   VSoft.MSXML6 in '..\DUnitXML\VSoft.MSXML6.pas',
   Delphi.Mocks.WeakReference in '..\Delphi.Mocks.WeakReference.pas',


### PR DESCRIPTION
… value defined. When calling a expected function with invalid arguments, the expectation is not matched, but the exception does not show the args used.