### PR TITLE
Fixed expectations to use matches as well.

### DIFF
--- a/Delphi.Mocks.Expectation.pas
+++ b/Delphi.Mocks.Expectation.pas
@@ -144,8 +144,6 @@ begin
   FMatchers := matchers;
 end;
 
-
-
 constructor TExpectation.CreateAfter(const AMethodName : string; const AAfterMethodName: string);
 begin
   Create(AMethodName);

--- a/Delphi.Mocks.Proxy.pas
+++ b/Delphi.Mocks.Proxy.pas
@@ -478,6 +478,9 @@ begin
         //first see if we know about this method
         methodData := GetMethodData(method.Name, pInfo.NameStr);
         Assert(methodData <> nil);
+
+        matchers := TMatcherFactory.GetMatchers;
+
         case FNextExpectation of
           OnceWhen        : methodData.OnceWhen(Args, matchers);
           NeverWhen       : methodData.NeverWhen(Args, matchers) ;


### PR DESCRIPTION
Previously matches were not being retrieved when an expectation was being called.