### PR TITLE
TValue support for ole variant and Variant array of Variant

### DIFF
--- a/Delphi.Mocks.Helpers.pas
+++ b/Delphi.Mocks.Helpers.pas
@@ -38,7 +38,6 @@ uses
 type
   //TValue really needs to have an Equals operator overload!
   TValueHelper = record helper for TValue
-    class function FromVariant(const Value: Variant): TValue; static;
     function Equals(const value : TValue) : boolean;
     function IsFloat: Boolean;
     function IsNumeric: Boolean;
@@ -105,10 +104,44 @@ begin
   end;
 end;
 
-function SameValue(const Left, Right: TValue): Boolean;
+function SameVariant(const Left, Right: Variant): Boolean;
 var
-  varLeft, varRight: variant;
   i: integer;
+begin
+  // here, we are going to check to the best of our ability that the variants are the same.
+  // simply a = b is not enough in some cases with variants
+
+  // a varArray of variants needs to be correctly checked, as implicit comparison does not work
+  if ( VarType(Left) = VarType(Right) ) AND
+     ( VarType(Left) = varArray + varVariant ) then
+  begin
+    // first check if the pointers are the same, which would indicate the same variant instance
+    Result := @Left = @Right;
+
+    if NOT Result then
+    begin
+      // second, we can check if the array length is the same, which would be a quick way to determine NOT being the same array
+      Result := VarArrayHighBound(Left, 1) = VarArrayHighBound(Right, 1);
+
+      if Result then
+      begin
+        Result := True; // be optimistic and look for where values dont match
+
+        for i := VarArrayLowBound(Left,1) to VarArrayHighBound(Left,1) do
+        begin
+          // recurse down as it may be multi-dimensional array
+          Result := SameVariant(Left[i], Right[i]);
+          if NOT Result then
+            Break;
+        end;
+      end;
+    end;
+  end
+  else
+    Result := Left = Right;
+end;
+
+function SameValue(const Left, Right: TValue): Boolean;
 begin
   if Left.IsNumeric and Right.IsNumeric then
   begin
@@ -207,36 +240,7 @@ begin
   end else
   if Left.IsVariant and Right.IsVariant then
   begin
-    varLeft  := Left.AsVariant;
-    varRight := Right.AsVariant;
-
-    // a varArray of variants needs to be correctly checked, as implicit comparison does not work
-    if ( VarType(varLeft) = VarType(varRight) ) AND
-       ( VarType(varLeft) = varArray + varVariant ) then
-    begin
-      // first check if the pointers are the same, which would indicate the same variant instance
-      Result := @varLeft = @varRight;
-
-      if NOT Result then
-      begin
-        // second, we can check if the array length is the same, which would be a quick way to determine NOT being the same array
-        Result := VarArrayHighBound(varLeft, 1) = VarArrayHighBound(varRight, 1);
-
-        if Result then
-        begin
-          Result := True; // be optimistic and look for where values dont match
-
-          for i := VarArrayLowBound(varLeft,1) to VarArrayHighBound(varLeft,1) do
-          begin
-            Result := varLeft[i] = varRight[i];
-            if NOT Result then
-              Break;
-          end;
-        end;
-      end;
-    end
-    else
-      Result := Left.AsVariant = Right.AsVariant;
+    Result := SameVariant(Left.AsVariant, Right.AsVariant);
   end else
   if Left.IsGuid and Right.IsGuid then
   begin
@@ -252,44 +256,6 @@ begin
 end;
 
 { TValueHelper }
-
-class function TValueHelper.FromVariant(const Value: Variant): TValue;
-begin
-  // This code is a copy of the code from XE7 TValue.FromVariant.
-  // Record Helpers do not allow inheritance, and so we are replacing the
-  // FromVariant call with this one with no way to call the Rtti method.
-  // That code does not support 8204, which is an array of variants.
-  // This has been added to the case below.
-
-  case TVarData(Value).VType of
-    varEmpty, varNull: Exit(Empty);
-    varBoolean: Result := TVarData(Value).VBoolean;
-    varShortInt: Result := TVarData(Value).VShortInt;
-    varSmallint: Result := TVarData(Value).VSmallInt;
-    varInteger: Result := TVarData(Value).VInteger;
-    varSingle: Result := TVarData(Value).VSingle;
-    varDouble: Result := TVarData(Value).VDouble;
-    varCurrency: Result := TVarData(Value).VCurrency;
-    varDate: Result := From<TDateTime>(TVarData(Value).VDate);
-    varOleStr: Result := string(TVarData(Value).VOleStr);
-    varDispatch: Result := From<IDispatch>(IDispatch(TVarData(Value).VDispatch));
-    varError: Result := From<HRESULT>(TVarData(Value).VError);
-    varUnknown: Result := From<IInterface>(IInterface(TVarData(Value).VUnknown));
-    varByte: Result := TVarData(Value).VByte;
-    varWord: Result := TVarData(Value).VWord;
-    varLongWord: Result := TVarData(Value).VLongWord;
-    varInt64: Result := TVarData(Value).VInt64;
-    varUInt64: Result := TVarData(Value).VUInt64;
-{$IFNDEF NEXTGEN}
-    varString: Result := string(AnsiString(TVarData(Value).VString));
-{$ENDIF !NEXTGEN}
-    varUString: Result := UnicodeString(TVarData(Value).VUString);
-
-    varArray + varVariant: Result := From<Variant>(Value);
-  else
-    raise EVariantTypeCastError.CreateRes(@SInvalidVarCast);
-  end;
-end;
 
 function TValueHelper.AsDouble: Double;
 begin
@@ -408,7 +374,8 @@ end;
 
 function TValueHelper.IsVariant: Boolean;
 begin
-  Result := TypeInfo = System.TypeInfo(Variant);
+  Result := ( TypeInfo = System.TypeInfo(Variant) ) OR
+            ( TypeInfo = System.TypeInfo(OLEVariant) );
 end;
 
 function TValueHelper.IsWord: Boolean;

--- a/Delphi.Mocks.Helpers.pas
+++ b/Delphi.Mocks.Helpers.pas
@@ -127,7 +127,7 @@ begin
       begin
         Result := True; // be optimistic and look for where values dont match
 
-        for i := VarArrayLowBound(Left,1) to VarArrayHighBound(Left,1) do
+        for i := VarArrayLowBound(Left,1) to VarArrayHighBound(Left,1) - 1 do
         begin
           // recurse down as it may be multi-dimensional array
           Result := SameVariant(Left[i], Right[i]);

--- a/Delphi.Mocks.Helpers.pas
+++ b/Delphi.Mocks.Helpers.pas
@@ -127,7 +127,7 @@ begin
       begin
         Result := True; // be optimistic and look for where values dont match
 
-        for i := VarArrayLowBound(Left,1) to VarArrayHighBound(Left,1) - 1 do
+        for i := VarArrayLowBound(Left,1) to VarArrayHighBound(Left,1) do
         begin
           // recurse down as it may be multi-dimensional array
           Result := SameVariant(Left[i], Right[i]);

--- a/Tests/Delphi.Mocks.Tests.Utils.pas
+++ b/Tests/Delphi.Mocks.Tests.Utils.pas
@@ -10,20 +10,38 @@ type
   //Testing TValue helper methods in TValueHelper
   TTestTValue = class(TTestCase)
   published
+    // INTERFACE
     procedure Test_TValue_Equals_Interfaces;
     procedure Test_TValue_NotEquals_Interfaces;
+
+    // STRING
     procedure Test_TValue_Equals_Strings;
     procedure Test_TValue_NotEquals_Strings;
 
+    // GUID
     procedure Test_TValue_Equals_SameGuid_Instance;
     procedure Test_TValue_Equals_DifferentGuid_Instance;
     procedure Test_TValue_NotEquals_Guid;
+
+    // VARIANT
+    // includes tests for VarArray of variant
+    procedure Test_TValue_Equals_Variants;
+    procedure Test_TValue_Equals_Variants_BothEmpty;
+    procedure Test_TValue_Equals_Variants_BothUnAssigned;
+    procedure Test_TValue_Equals_Variants_VarArray;
+    procedure Test_TValue_Equals_Variants_VarArray_DifferentInstances;
+    procedure Test_TValue_NotEquals_Variants;
+    procedure Test_TValue_NotEquals_Variants_OneEmpty;
+    procedure Test_TValue_NotEquals_Variants_OneUnAssigned;
+    procedure Test_TValue_NotEquals_Variants_VarArray_DifferentLengths;
+    procedure Test_TValue_NotEquals_Variants_VarArray_DifferentContent;
   end;
 
 implementation
 
 uses
-  SysUtils;
+  SysUtils,
+  Variants;
 
 
 { TTestTValue }
@@ -112,6 +130,154 @@ begin
   v2 := s2;
   CheckFalse(v1.Equals(v2));
 end;
+
+
+procedure TTestTValue.Test_TValue_Equals_Variants;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := 'hello';
+  var2 := 'hello';
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_Variants_BothEmpty;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := varEmpty;
+  var2 := varEmpty;
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_Variants_BothUnAssigned;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := UnAssigned;
+  var2 := UnAssigned;
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_Variants_VarArray;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := VarArrayCreate( [0,3], varVariant );
+  var1[0] := '0';
+  var1[1] := '1';
+  var1[2] := '2';
+  var2 := VarArrayCreate( [0,3], varVariant );
+  var2[0] := '0';
+  var2[1] := '1';
+  var2[2] := '2';
+
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_Variants_VarArray_DifferentInstances;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := VarArrayCreate( [0,3], varVariant );
+  var1[0] := '0';
+  var1[1] := '1';
+  var1[2] := '2';
+  var2 := VarArrayCreate( [0,3], varVariant );
+  var2[0] := '0';
+  var2[1] := '1';
+  var2[2] := '2';
+
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_Variants;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := 'hello';
+  var2 := 'goodbye';
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_Variants_OneEmpty;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := 'hello';
+  var2 := varEmpty;
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_Variants_OneUnAssigned;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := 'hello';
+  var2 := UnAssigned;
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_Variants_VarArray_DifferentLengths;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := VarArrayCreate( [0,3], varVariant );
+  var1[0] := '0';
+  var1[1] := '1';
+  var1[2] := '2';
+  var2 := VarArrayCreate( [0,2], varVariant );
+  var2[0] := '0';
+  var2[1] := '1';
+
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+procedure TTestTValue.Test_TValue_NotEquals_Variants_VarArray_DifferentContent;
+var
+  var1,var2 : variant;
+  v1, v2 : TValue;
+begin
+  var1 := VarArrayCreate( [0,3], varVariant );
+  var1[0] := 'a';
+  var1[1] := 'b';
+  var1[2] := 'c';
+  var2 := VarArrayCreate( [0,3], varVariant );
+  var2[0] := '0';
+  var2[1] := '1';
+  var2[2] := '2';
+
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
 
 initialization
   TestFramework.RegisterTest(TTestTValue.Suite);

--- a/Tests/Delphi.Mocks.Tests.Utils.pas
+++ b/Tests/Delphi.Mocks.Tests.Utils.pas
@@ -25,6 +25,10 @@ type
 
     // VARIANT
     // includes tests for VarArray of variant
+    // when using Variants with varArray of Variant, you need to follow the code convention
+    //  Assign to TValue using, TValue.From<Variant>(myVar)
+    //  Do not use TValue.FromVariant, as this does not support varArray
+    //  Otherwise, it will work as expected
     procedure Test_TValue_Equals_Variants;
     procedure Test_TValue_Equals_Variants_BothEmpty;
     procedure Test_TValue_Equals_Variants_BothUnAssigned;
@@ -35,6 +39,21 @@ type
     procedure Test_TValue_NotEquals_Variants_OneUnAssigned;
     procedure Test_TValue_NotEquals_Variants_VarArray_DifferentLengths;
     procedure Test_TValue_NotEquals_Variants_VarArray_DifferentContent;
+
+    procedure Test_TValue_Equals_Variants_VarArray_Of_Variant;
+    procedure Test_TValue_NotEquals_Variants_VarArray_Of_Variant;
+
+    // OLEVARIANT
+    procedure Test_TValue_Equals_OLEVariants;
+    procedure Test_TValue_Equals_OLEVariants_BothEmpty;
+    procedure Test_TValue_Equals_OLEVariants_BothUnAssigned;
+    procedure Test_TValue_Equals_OLEVariants_VarArray;
+    procedure Test_TValue_Equals_OLEVariants_VarArray_DifferentInstances;
+    procedure Test_TValue_NotEquals_OLEVariants;
+    procedure Test_TValue_NotEquals_OLEVariants_OneEmpty;
+    procedure Test_TValue_NotEquals_OLEVariants_OneUnAssigned;
+    procedure Test_TValue_NotEquals_OLEVariants_VarArray_DifferentLengths;
+    procedure Test_TValue_NotEquals_OLEVariants_VarArray_DifferentContent;
   end;
 
 implementation
@@ -182,8 +201,8 @@ begin
   var2[1] := '1';
   var2[2] := '2';
 
-  v1 := TValue.FromVariant( var1 );
-  v2 := TValue.FromVariant( var2 );
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
   CheckTrue(v1.Equals(v2));
 end;
 
@@ -201,9 +220,9 @@ begin
   var2[1] := '1';
   var2[2] := '2';
 
-  v1 := TValue.FromVariant( var1 );
-  v2 := TValue.FromVariant( var2 );
-  CheckFalse(v1.Equals(v2));
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
+  CheckTrue(v1.Equals(v2));
 end;
 
 procedure TTestTValue.Test_TValue_NotEquals_Variants;
@@ -255,8 +274,8 @@ begin
   var2[0] := '0';
   var2[1] := '1';
 
-  v1 := TValue.FromVariant( var1 );
-  v2 := TValue.FromVariant( var2 );
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
   CheckFalse(v1.Equals(v2));
 end;
 procedure TTestTValue.Test_TValue_NotEquals_Variants_VarArray_DifferentContent;
@@ -273,8 +292,211 @@ begin
   var2[1] := '1';
   var2[2] := '2';
 
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_Variants_VarArray_Of_Variant;
+var
+  var1,var2, inner1, inner2 : variant;
+  v1, v2 : TValue;
+begin
+  var1   := VarArrayCreate( [0,3], varVariant );
+  inner1 := VarArrayCreate( [0,3], varVariant );
+  inner1[0] := '1';
+  inner1[1] := '1';
+  inner1[2] := '1';
+  var1[0] := inner1;
+  var1[1] := inner1;
+  var1[2] := inner1;
+
+  var2   := VarArrayCreate( [0,3], varVariant );
+  inner2 := VarArrayCreate( [0,3], varVariant );
+  inner2[0] := '1';
+  inner2[1] := '1';
+  inner2[2] := '1';
+  var2[0] := inner2;
+  var2[1] := inner2;
+  var2[2] := inner2;
+
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_Variants_VarArray_Of_Variant;
+var
+  var1,var2, inner1, inner2 : variant;
+  v1, v2 : TValue;
+begin
+  var1   := VarArrayCreate( [0,3], varVariant );
+  inner1 := VarArrayCreate( [0,3], varVariant );
+  inner1[0] := '1';
+  inner1[1] := '1';
+  inner1[2] := '1';
+  var1[0] := inner1;
+  var1[1] := inner1;
+  var1[2] := inner1;
+
+  var2   := VarArrayCreate( [0,3], varVariant );
+  inner2 := VarArrayCreate( [0,3], varVariant );
+  inner2[0] := '22';
+  inner2[1] := '22';
+  inner2[2] := '22';
+  var2[0] := inner2;
+  var2[1] := inner2;
+  var2[2] := inner2;
+
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+
+procedure TTestTValue.Test_TValue_Equals_OLEVariants;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := 'hello';
+  var2 := 'hello';
   v1 := TValue.FromVariant( var1 );
   v2 := TValue.FromVariant( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_OLEVariants_BothEmpty;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := varEmpty;
+  var2 := varEmpty;
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_OLEVariants_BothUnAssigned;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := UnAssigned;
+  var2 := UnAssigned;
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_OLEVariants_VarArray;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := VarArrayCreate( [0,3], varVariant );
+  var1[0] := '0';
+  var1[1] := '1';
+  var1[2] := '2';
+  var2 := VarArrayCreate( [0,3], varVariant );
+  var2[0] := '0';
+  var2[1] := '1';
+  var2[2] := '2';
+
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_Equals_OLEVariants_VarArray_DifferentInstances;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := VarArrayCreate( [0,3], varVariant );
+  var1[0] := '0';
+  var1[1] := '1';
+  var1[2] := '2';
+  var2 := VarArrayCreate( [0,3], varVariant );
+  var2[0] := '0';
+  var2[1] := '1';
+  var2[2] := '2';
+
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
+  CheckTrue(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_OLEVariants;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := 'hello';
+  var2 := 'goodbye';
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_OLEVariants_OneEmpty;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := 'hello';
+  var2 := varEmpty;
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_OLEVariants_OneUnAssigned;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := 'hello';
+  var2 := UnAssigned;
+  v1 := TValue.FromVariant( var1 );
+  v2 := TValue.FromVariant( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+
+procedure TTestTValue.Test_TValue_NotEquals_OLEVariants_VarArray_DifferentLengths;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := VarArrayCreate( [0,3], varVariant );
+  var1[0] := '0';
+  var1[1] := '1';
+  var1[2] := '2';
+  var2 := VarArrayCreate( [0,2], varVariant );
+  var2[0] := '0';
+  var2[1] := '1';
+
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
+  CheckFalse(v1.Equals(v2));
+end;
+procedure TTestTValue.Test_TValue_NotEquals_OLEVariants_VarArray_DifferentContent;
+var
+  var1,var2 : OLEVariant;
+  v1, v2 : TValue;
+begin
+  var1 := VarArrayCreate( [0,3], varVariant );
+  var1[0] := 'a';
+  var1[1] := 'b';
+  var1[2] := 'c';
+  var2 := VarArrayCreate( [0,3], varVariant );
+  var2[0] := '0';
+  var2[1] := '1';
+  var2[2] := '2';
+
+  v1 := TValue.From<Variant>( var1 );
+  v2 := TValue.From<Variant>( var2 );
   CheckFalse(v1.Equals(v2));
 end;
 


### PR DESCRIPTION
I could not get TValue.FromVariant to support variant array of variants. 

To work with this, you need to set TValue using TValue.From<Variant>(myvar)

The rest is now supported in SameValue using a SameVariant function to try and determine a comparison on the Left/Right Variants if they are arrays
