### PR TITLE
Will return nil

### DIFF
--- a/Delphi.Mocks.Proxy.pas
+++ b/Delphi.Mocks.Proxy.pas
@@ -66,6 +66,7 @@ type
     //behavior setup
     FNextBehavior           : TBehaviorType;
     FReturnValue            : TValue;
+    FReturnValueNilAllowed  : Boolean;
     FNextFunc               : TExecuteFunc;
     FExceptClass            : ExceptClass;
     FExceptionMessage       : string;
@@ -129,6 +130,7 @@ type
     {$Message 'TODO: Implement ISetup.Before and ISetup.After.'}
     function WillReturn(const value : TValue) : IWhen<T>;
     procedure WillReturnDefault(const AMethodName : string; const value : TValue);
+    function WillReturnNil: IWhen<T>;
     function WillRaise(const exceptionClass : ExceptClass; const message : string = '') : IWhen<T>; overload;
     procedure WillRaise(const AMethodName : string; const exceptionClass : ExceptClass; const message : string = ''); overload;
 
@@ -457,7 +459,8 @@ begin
             //We don't test for the return type being valid as XE5 and below have a RTTI bug which does not return
             //a return type for function which reference their own class/interface. Even when RTTI is specified on
             //the declaration and forward declaration.
-            if (FReturnValue.IsEmpty) then
+            if (FReturnValue.IsEmpty and not FReturnValueNilAllowed) or
+              (FReturnValueNilAllowed and ((FReturnValue.TypeInfo = nil) or (FReturnValue.TypeData = nil))) then
               raise EMockSetupException.CreateFmt('Setup.WillReturn call on method [%s] was not passed a return value.', [Method.Name]);
 
             methodData.WillReturnWhen(Args,FReturnValue,matchers);
@@ -808,6 +811,15 @@ begin
   Assert(methodData <> nil);
   methodData.WillReturnDefault(value);
   ClearSetupState;
+end;
+
+function TProxy<T>.WillReturnNil: IWhen<T>;
+begin
+  FSetupMode := TSetupMode.Behavior;
+  FReturnValue := TValue.From<Pointer>(nil);
+  FReturnValueNilAllowed := True;
+  FNextBehavior := TBehaviorType.WillReturn;
+  result := TWhen<T>.Create(Self.Proxy);
 end;
 
 function TProxy<T>._AddRef: Integer;

--- a/Delphi.Mocks.Proxy.pas
+++ b/Delphi.Mocks.Proxy.pas
@@ -128,7 +128,8 @@ type
     function Expect : IExpect<T>;
 
     {$Message 'TODO: Implement ISetup.Before and ISetup.After.'}
-    function WillReturn(const value : TValue) : IWhen<T>;
+    function WillReturn(const value : TValue) : IWhen<T>; overload;
+    function WillReturn(const value : TValue; const AllowNil: Boolean) : IWhen<T>; overload;
     procedure WillReturnDefault(const AMethodName : string; const value : TValue);
     function WillReturnNil: IWhen<T>;
     function WillRaise(const exceptionClass : ExceptClass; const message : string = '') : IWhen<T>; overload;
@@ -796,6 +797,15 @@ function TProxy<T>.WillReturn(const value: TValue): IWhen<T>;
 begin
   FSetupMode := TSetupMode.Behavior;
   FReturnValue := value;
+  FNextBehavior := TBehaviorType.WillReturn;
+  result := TWhen<T>.Create(Self.Proxy);
+end;
+
+function TProxy<T>.WillReturn(const value: TValue; const AllowNil: Boolean): IWhen<T>;
+begin
+  FSetupMode := TSetupMode.Behavior;
+  FReturnValue := value;
+  FReturnValueNilAllowed := AllowNil;
   FNextBehavior := TBehaviorType.WillReturn;
   result := TWhen<T>.Create(Self.Proxy);
 end;

--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -95,6 +95,9 @@ type
     //set the return value for a method when called with the parameters specified on the When
     function WillReturn(const value : TValue) : IWhen<T>;
 
+    //set the nil as return value for a method when called with the parameters specified on the When
+    function WillReturnNil : IWhen<T>;
+
     //Will exedute the func when called with the specified parameters
     function WillExecute(const func : TExecuteFunc) : IWhen<T>;overload;
 

--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -93,7 +93,11 @@ type
     procedure SetAllowRedefineBehaviorDefinitions(const value : boolean);
 
     //set the return value for a method when called with the parameters specified on the When
-    function WillReturn(const value : TValue) : IWhen<T>;
+    function WillReturn(const value : TValue) : IWhen<T>; overload;
+
+    //set the return value for a method when called with the parameters specified on the When
+    //AllowNil flag allow to define: returning nil value is allowed or not.
+    function WillReturn(const value : TValue; const AllowNil: Boolean) : IWhen<T>; overload;
 
     //set the nil as return value for a method when called with the parameters specified on the When
     function WillReturnNil : IWhen<T>;


### PR DESCRIPTION
In some unit tests I'm testing what will happens if object replaced by stub or mock returns nil value. For long time I used old version of Delphi Mocks (revision from 17 March 2014) In this version it was possible to use following code:
```
stub.Setup.WillReturn(TValue.From(nil)).When.SomeFunction;
```
After updating to the current version this code not works any more. While executing this function an exception is raised:

> Setup.WillReturn call on method [GetPozycjeVM] was not passed a return value.

its because in procedure TProxy<T>.DoInvoke exist condition:
```
if (FReturnValue.IsEmpty) then
  raise EMockSetupException.CreateFmt('Setup.WillReturn call on method [%s] was not passed a return value.', [Method.Name]);
```
TValue.IsEmpty function allways returns True for nil pointer. To avoid this problem I have added two functions which allows to prepare stubs or mocks which returns nil values. I hope you will accept this.

best regards
Adam Siwon
