### PR TITLE
Erro a compilar com o "Emit runtime type information"

### DIFF
--- a/Delphi.Mocks.Proxy.TypeInfo.pas
+++ b/Delphi.Mocks.Proxy.TypeInfo.pas
@@ -39,6 +39,8 @@ uses
   Delphi.Mocks.Behavior;
 
 type
+  {$M-}
+
   TProxy = class(TWeakReferencedObject, IWeakReferenceableObject, IInterface, IProxy, IVerify)
   private
     FTypeInfo               : PTypeInfo;

--- a/Delphi.Mocks.Proxy.pas
+++ b/Delphi.Mocks.Proxy.pas
@@ -38,6 +38,8 @@ uses
   Delphi.Mocks.Behavior;
 
 type
+  {$M-}
+
   TProxyBaseInvokeEvent = procedure (Method: TRttiMethod; const Args: TArray<TValue>; out Result: TValue) of object;
 
   TSetupMode = (None, Behavior, Expectation);

--- a/Delphi.Mocks.WeakReference.pas
+++ b/Delphi.Mocks.WeakReference.pas
@@ -46,6 +46,8 @@ Delphi 2010 and has so far proven to be very reliable.
 interface
 
 type
+  {$M-}
+
   /// Implemented by our weak referenced object base class
   IWeakReferenceableObject = interface
     ['{3D7F9CB5-27F2-41BF-8C5F-F6195C578755}']

--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -39,6 +39,8 @@ uses
   Delphi.Mocks.WeakReference;
 
 type
+  {$M-}
+
   IWhen<T> = interface;
 
   //Records the expectations we have when our Mock is used. We can then verify


### PR DESCRIPTION
…cc32 Error] Delphi.Mocks.pas(253): E2134 Type '<void>' has no type info", com isso coloquei a diretiva "{$M-}", nas units que tem alguma declaração do tipo "out", e a váriavel não tiver tipo, para evitar esse erro.