### PR TITLE
Wrong ItRec.IsNotNil function result.

### DIFF
--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -754,7 +754,7 @@ begin
       comparer : IEqualityComparer<T>;
     begin
       comparer := TEqualityComparer<T>.Default;
-      result := comparer.Equals(param,Default(T));
+      result := not comparer.Equals(param,Default(T));
     end);
 
 end;


### PR DESCRIPTION
Hi,

I found problem with results from ItRec.IsNotNil function. For following example:

  mock := TMock<ITest>.Create;
  mock.Setup.Expect.Once.When.Test(It0.IsNotNil<ITest>);
  mock.Instance.Test(mock.Instance);
  mock.Verify();

an exception is raised while mock.Verify() is executed. But code:

mock := TMock<ITest>.Create;
mock.Setup.Expect.Once.When.Test(It0.IsNotNil<ITest>);
mock.Instance.Test(nil);
mock.Verify();

works without any exception. I think it should be vice versa. I made small correction to the ItRec.IsNotNil function code. 



