### PR TITLE
Update Delphi.Mocks.Proxy.pas

### DIFF
--- a/Delphi.Mocks.Proxy.pas
+++ b/Delphi.Mocks.Proxy.pas
@@ -578,21 +578,31 @@ begin
 
   FQueryingInternalInterface := True;
   try
+    Result := FVirtualInterface.QueryInterface(IID, obj);
+    if Result = S_OK then
+      Exit;
+
     //Otherwise look in the list of interface proxies that might have been implemented
     if (FInterfaceProxies.ContainsKey(IID)) then
     begin
       virtualProxy := FInterfaceProxies.Items[IID];
       Result := virtualProxy.ProxyInterface.QueryInterface(IID, Obj);
 
-      if result = S_OK then
+      if Result = S_OK then
         Exit;
     end;
 
-    {$Message 'TODO: Need to query the parent, but exclude outselves and any other children which have already been called.'}
+    { $Message 'TODO: Need to query the parent, but exclude outselves and any other children which have already been called.'}
 
     //Call the parent.
     if FParentProxy <> nil then
+    begin
       Result := FParentProxy.Data.QueryInterface(IID, obj);
+      if Result = S_OK then
+        Exit;
+
+      Result := FParentProxy.Data.QueryImplementedInterface(IID, obj);
+    end;
   finally
     FQueryingInternalInterface := False;
   end;


### PR DESCRIPTION
Fix for Mocks implementing multiple interfaces. When accessing the mock from different interfaces there will be an "Interface not supported" exception, while the real object implements al the interfaces and the mock seams not to. See code:

FBookAccount := TMock<IBookAccount>.Create;
FBookAccount.Implement<IPersistObject>;
FBookAccount.Implement<IModifiable>;
FBookAccount.Implement<IAsObjectInterface>;

// this worked:

a := FBookAccount;
b := a as IPersistObject;
c := a as IModifiable;
d := a as IAsObjectInterface;
i := a as IInterface;

// this did not work with the mock 
a := FBookAccount;
b := a as IPersistObject;
c := b as IModifiable;
d := c as IAsObjectInterface;
i := d as IInterface;