### PR TITLE
Problemas com parâmetros de função como enumeradores

### DIFF
--- a/Delphi.Mocks.Behavior.pas
+++ b/Delphi.Mocks.Behavior.pas
@@ -220,7 +220,7 @@ begin
         raise FExceptClass.Create('Raised by Mock');
     end;
     WillRaiseAlways : result := True;
-    WillExecuteWhen :  result := MatchArgs;
+    WillExecuteWhen : result := MatchArgs;
     WillExecute     : result := True;
   end;
 end;

--- a/Delphi.Mocks.MethodData.pas
+++ b/Delphi.Mocks.MethodData.pas
@@ -205,6 +205,10 @@ begin
   if Result <> nil then
     exit;
 
+  result := FindBehavior(TBehaviorType.WillRaise, Args);
+  if Result <> nil then
+    exit;
+
   //then find an always execute
   result := FindBehavior(TBehaviorType.WillExecute);
   if Result <> nil then

--- a/Delphi.Mocks.Proxy.pas
+++ b/Delphi.Mocks.Proxy.pas
@@ -144,6 +144,8 @@ type
     function WillRaise(const exceptionClass : ExceptClass; const message : string = '') : IWhen<T>; overload;
     procedure WillRaise(const AMethodName : string; const exceptionClass : ExceptClass; const message : string = ''); overload;
 
+    function WillRaiseWhen(const exceptionClass : ExceptClass; const message : string = '') : IWhen<T>;
+
     function WillExecute(const func : TExecuteFunc) : IWhen<T>; overload;
     procedure WillExecute(const AMethodName : string; const func : TExecuteFunc); overload;
 
@@ -477,6 +479,10 @@ begin
           end;
           TBehaviorType.WillRaise:
           begin
+            methodData.WillRaiseWhen(FExceptClass, FExceptionMessage, Args, matchers);
+          end;
+          TBehaviorType.WillRaiseAlways:
+          begin
             methodData.WillRaiseAlways(FExceptClass,FExceptionMessage);
           end;
           TBehaviorType.WillExecuteWhen :
@@ -798,7 +804,7 @@ end;
 function TProxy<T>.WillRaise(const exceptionClass: ExceptClass;const message : string): IWhen<T>;
 begin
   FSetupMode := TSetupMode.Behavior;
-  FNextBehavior := TBehaviorType.WillRaise;
+  FNextBehavior := TBehaviorType.WillRaiseAlways;
   FExceptClass := exceptionClass;
   FExceptionMessage := message;
   result := TWhen<T>.Create(Self.Proxy);
@@ -815,6 +821,15 @@ begin
   Assert(methodData <> nil);
   methodData.WillRaiseAlways(exceptionClass,message);
   ClearSetupState;
+end;
+
+function TProxy<T>.WillRaiseWhen(const exceptionClass: ExceptClass; const message: string): IWhen<T>;
+begin
+  FSetupMode := TSetupMode.Behavior;
+  FNextBehavior := TBehaviorType.WillRaise;
+  FExceptClass := exceptionClass;
+  FExceptionMessage := message;
+  result := TWhen<T>.Create(Self.Proxy);
 end;
 
 function TProxy<T>.WillReturn(const value: TValue): IWhen<T>;

--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -709,7 +709,7 @@ end;
 
 function ItRec.IsEqualTo<T>(const value : T) : T;
 begin
-  result := Default(T);
+  Result := Value;
 
   TMatcherFactory.Create<T>(ParamIndex,
     function(param : T) : boolean

--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -661,7 +661,7 @@ end;
 
 function ItRec.AreSameFieldsAndPropertiedThat<T>(const Value: T): T;
 begin
-  Result := Default(T);
+  Result := Value;
 
   TMatcherFactory.Create<T>(ParamIndex,
     function(Param: T): Boolean
@@ -672,7 +672,7 @@ end;
 
 function ItRec.AreSameFieldsThat<T>(const Value: T): T;
 begin
-  Result := Default(T);
+  Result := Value;
 
   TMatcherFactory.Create<T>(ParamIndex,
     function(Param: T): Boolean
@@ -683,7 +683,7 @@ end;
 
 function ItRec.AreSamePropertiesThat<T>(const Value: T): T;
 begin
-  Result := Default(T);
+  Result := Value;
 
   TMatcherFactory.Create<T>(ParamIndex,
     function(Param: T): Boolean

--- a/Delphi.Mocks.pas
+++ b/Delphi.Mocks.pas
@@ -118,6 +118,9 @@ type
     //This method will always raise an exception.. this behavior will trump any other defined behaviors
     procedure WillRaise(const AMethodName : string; const exceptionClass : ExceptClass; const message : string = '');overload;
 
+    //set the Exception class that will be raised when the method is called with the parmeters specified
+    function WillRaiseWhen(const exceptionClass: ExceptClass; const message: string = ''): IWhen<T>;
+
     //If true, calls to methods for which we have not defined a behavior will cause verify to fail.
     property BehaviorMustBeDefined : boolean read GetBehaviorMustBeDefined write SetBehaviorMustBeDefined;
 

--- a/Tests/Delphi.Mocks.Examples.Matchers.pas
+++ b/Tests/Delphi.Mocks.Examples.Matchers.pas
@@ -14,15 +14,29 @@ type
   end;
 
   ILoan = interface
+  end;
 
+  TEnumerator = (Value1, Value2, Value3);
+
+  IInterfaceToTestWithEnumerator = interface
+    ['{45799970-833E-4419-A683-24E07AD742C2}']
+    function AnyFuntionWithEnumerator(Enumerator: TEnumerator): Integer;
+    function AnyFuntionWithInteger(Value: Integer): Integer;
   end;
   {$M-}
 
+  {$M+}
+  [TestFixture]
   TExample_MatchersTests = class
   published
+    [Test]
     procedure Match_parameter_values;
+    [Test]
+    procedure Match_parameter_with_enumerators;
+    [Test]
+    procedure Match_parameter_with_diferent_values;
   end;
-
+  {$M-}
 
 implementation
 
@@ -58,7 +72,42 @@ end;
 
 { TScorer }
 
+procedure TExample_MatchersTests.Match_parameter_with_diferent_values;
+var
+  Mock: TMock<IInterfaceToTestWithEnumerator>;
+
+begin
+  Mock := TMock<IInterfaceToTestWithEnumerator>.Create;
+
+  Mock.Setup.WillReturn(-1).When.AnyFuntionWithInteger(It0.IsEqualTo(0));
+  Mock.Setup.WillReturn(10).When.AnyFuntionWithInteger(It0.IsEqualTo(1));
+  Mock.Setup.WillReturn(20).When.AnyFuntionWithInteger(It0.IsEqualTo(2));
+  Mock.Setup.WillReturn(30).When.AnyFuntionWithInteger(It0.IsEqualTo(3));
+
+  Assert.AreEqual(-1, Mock.Instance.AnyFuntionWithInteger(0));
+  Assert.AreEqual(10, Mock.Instance.AnyFuntionWithInteger(1));
+  Assert.AreEqual(20, Mock.Instance.AnyFuntionWithInteger(2));
+  Assert.AreEqual(30, Mock.Instance.AnyFuntionWithInteger(3));
+end;
+
+procedure TExample_MatchersTests.Match_parameter_with_enumerators;
+var
+  Mock: TMock<IInterfaceToTestWithEnumerator>;
+
+begin
+  Mock := TMock<IInterfaceToTestWithEnumerator>.Create;
+
+  Mock.Setup.WillReturn(10).When.AnyFuntionWithEnumerator(It0.IsEqualTo(Value1));
+  Mock.Setup.WillReturn(20).When.AnyFuntionWithEnumerator(It0.IsEqualTo(Value2));
+  Mock.Setup.WillReturn(30).When.AnyFuntionWithEnumerator(It0.IsEqualTo(Value3));
+
+  Assert.AreEqual(10, Mock.Instance.AnyFuntionWithEnumerator(Value1));
+  Assert.AreEqual(20, Mock.Instance.AnyFuntionWithEnumerator(Value2));
+  Assert.AreEqual(30, Mock.Instance.AnyFuntionWithEnumerator(Value3));
+end;
+
 initialization
   TDUnitX.RegisterTestFixture(TExample_MatchersTests);
 
 end.
+

--- a/Tests/Delphi.Mocks.Examples.Matchers.pas
+++ b/Tests/Delphi.Mocks.Examples.Matchers.pas
@@ -6,6 +6,15 @@ uses
   DUnitX.TestFramework;
 
 type
+  TObjectToTest = class
+  private
+    FPropertyToTest: Integer;
+  public
+    FieldToTest: Integer;
+
+    property PropertyToTest: Integer read FPropertyToTest write FPropertyToTest;
+  end;
+
   {$M+}
   IInterfaceToTest = interface
     ['{2AB032A9-ED5B-4FDC-904B-E3F1B2C78978}']
@@ -23,6 +32,11 @@ type
     function AnyFuntionWithEnumerator(Enumerator: TEnumerator): Integer;
     function AnyFuntionWithInteger(Value: Integer): Integer;
   end;
+
+  IInterfaceToTestWithObjects = interface
+    ['{45799970-833E-4419-A683-24E07AD742C2}']
+    function AnyFuntionWithObject(AObject: TObjectToTest): Integer;
+  end;
   {$M-}
 
   {$M+}
@@ -35,6 +49,8 @@ type
     procedure Match_parameter_with_enumerators;
     [Test]
     procedure Match_parameter_with_diferent_values;
+    [Test]
+    procedure Match_parameter_with_objects;
   end;
   {$M-}
 
@@ -104,6 +120,49 @@ begin
   Assert.AreEqual(10, Mock.Instance.AnyFuntionWithEnumerator(Value1));
   Assert.AreEqual(20, Mock.Instance.AnyFuntionWithEnumerator(Value2));
   Assert.AreEqual(30, Mock.Instance.AnyFuntionWithEnumerator(Value3));
+end;
+
+procedure TExample_MatchersTests.Match_parameter_with_objects;
+var
+  Mock: TMock<IInterfaceToTestWithObjects>;
+
+  Object1,
+  Object2,
+  Object3,
+  ObjectToCompare1,
+  ObjectToCompare2,
+  ObjectToCompare3: TObjectToTest;
+
+begin
+  Mock := TMock<IInterfaceToTestWithObjects>.Create;
+  Object1 := TObjectToTest.Create;
+  Object1.FieldToTest := 10;
+  Object1.PropertyToTest := 20;
+  Object2 := TObjectToTest.Create;
+  Object2.FieldToTest := 30;
+  Object2.PropertyToTest := 40;
+  Object3 := TObjectToTest.Create;
+  Object3.FieldToTest := 50;
+  Object3.PropertyToTest := 60;
+  ObjectToCompare1 := TObjectToTest.Create;
+  ObjectToCompare1.FieldToTest := 10;
+  ObjectToCompare1.PropertyToTest := 20;
+  ObjectToCompare2 := TObjectToTest.Create;
+  ObjectToCompare2.FieldToTest := 30;
+  ObjectToCompare2.PropertyToTest := 40;
+  ObjectToCompare3 := TObjectToTest.Create;
+  ObjectToCompare3.FieldToTest := 50;
+  ObjectToCompare3.PropertyToTest := 60;
+
+  Mock.Setup.WillReturn(10).When.AnyFuntionWithObject(It0.AreSameFieldsThat<TObjectToTest>(nil));
+  Mock.Setup.WillReturn(20).When.AnyFuntionWithObject(It0.AreSameFieldsThat(Object1));
+  Mock.Setup.WillReturn(30).When.AnyFuntionWithObject(It0.AreSamePropertiesThat(Object2));
+  Mock.Setup.WillReturn(40).When.AnyFuntionWithObject(It0.AreSameFieldsAndPropertiedThat(Object3));
+
+  Assert.AreEqual(10, Mock.Instance.AnyFuntionWithObject(nil));
+  Assert.AreEqual(20, Mock.Instance.AnyFuntionWithObject(ObjectToCompare1));
+  Assert.AreEqual(30, Mock.Instance.AnyFuntionWithObject(ObjectToCompare2));
+  Assert.AreEqual(40, Mock.Instance.AnyFuntionWithObject(ObjectToCompare3));
 end;
 
 initialization

--- a/Tests/Delphi.Mocks.Tests.dpr
+++ b/Tests/Delphi.Mocks.Tests.dpr
@@ -62,7 +62,8 @@ uses
   Delphi.Mocks.Tests.ProxyBase in 'Delphi.Mocks.Tests.ProxyBase.pas',
   Delphi.Mocks.Tests.TValue in 'Delphi.Mocks.Tests.TValue.pas',
   Delphi.Mocks.Tests.Utils in 'Delphi.Mocks.Tests.Utils.pas',
-  Delphi.Mocks.Utils.Tests in 'Delphi.Mocks.Utils.Tests.pas';
+  Delphi.Mocks.Utils.Tests in 'Delphi.Mocks.Utils.Tests.pas',
+  Delphi.Mocks.Examples.Matchers in 'Delphi.Mocks.Examples.Matchers.pas';
 
 {$R *.RES}
 


### PR DESCRIPTION
Adicionei uma unit de teste automatizados, ao projeto para testar o problema que estava tendo com enumeradores sendo passado de parâmetros, como ele carregava o retorno da função do ItRec.IsEqualTo com o valor padrão, ele não estava comparando os valores diferentes que eram fornecidos para a função, e com isso estava dando uma exceção que já tinha um matcher para aquele valor.
