### PR TITLE
Not enough Params being passed

### DIFF
--- a/Tests/Delphi.Mocks.Tests.ObjectProxy.pas
+++ b/Tests/Delphi.Mocks.Tests.ObjectProxy.pas
@@ -79,7 +79,10 @@ procedure TTestObjectProxy.ProxyObject_Calls_The_Create_Of_The_Object_Type;
 var
   objectProxy: IProxy<TSimpleObject>;
 begin
-  objectProxy := TObjectProxy<TSimpleObject>.Create;
+  objectProxy := TObjectProxy<TSimpleObject>.Create(function: TSimpleObject
+                                                    begin 
+                                                      result := TSimpleObject.Create; 
+                                                    end);
 
   Assert.AreEqual(objectProxy.Proxy.CreateCalled, G_CREATE_CALLED_UNIQUE_ID);
 end;
@@ -88,7 +91,10 @@ procedure TTestObjectProxy.ProxyObject_MultipleConstructor;
 var
   objectProxy: IProxy<TMultipleConstructor>;
 begin
-  objectProxy := TObjectProxy<TMultipleConstructor>.Create;
+  objectProxy := TObjectProxy<TMultipleConstructor>.Create(function: TMultipleConstructor
+                                                           begin 
+                                                             result := TMultipleConstructor.Create; 
+                                                           end);
 
   Assert.AreEqual(objectProxy.Proxy.CreateCalled, G_CREATE_CALLED_UNIQUE_ID);
 end;


### PR DESCRIPTION
Not enough parameters were being passed for TObjectProxy<T>.Create for tests:
ProxyObject_Calls_The_Create_Of_The_Object_Type
ProxyObject_MultipleConstructor