### PR TITLE
use relative submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "DUnitXML"]
 	path = DUnitXML
-	url = https://github.com/VSoftTechnologies/DUnit-XML.git
+	url = ../DUnit-XML.git


### PR DESCRIPTION
Using a relative url allows for ssh cloning of the submodule and better mirroring on servers behind a corporate proxy.