### PR TITLE
Solution for Issue #125 and reverted change made in commit e90fee5 related to {$M-}

### DIFF
--- a/Source/Delphi.Mocks.Helpers.pas
+++ b/Source/Delphi.Mocks.Helpers.pas
@@ -114,6 +114,9 @@ const
 var
   leftIsEmpty, rightIsEmpty: Boolean;
   CustomComparer: TCustomValueComparer;
+const
+  ErrorStr: String =  'Unable to compare %s. Use Delphi.Mocks.Helpers.TCustomValueComparerStore.RegisterCustomComparer<T> to add a ' +
+                      'method to compare records.';
 begin
   leftIsEmpty := left.IsEmpty;
   rightIsEmpty := right.IsEmpty;
@@ -132,7 +135,7 @@ begin
   else if Left.IsInterface and Right.IsInterface then
     Result := NativeInt(left.AsInterface) - NativeInt(right.AsInterface) // TODO: instance comparer
   else if Left.IsRecord and Right.IsRecord then
-    raise Exception.Create('Use Delphi.Mocks.Helpers.TCustomValueComparerStore.RegisterCustomComparer<T> to add a method to compare records.')
+    raise Exception.Create(Format(ErrorStr ,[Left.TypeInfo.Name]))
   else if left.IsVariant and right.IsVariant then
   begin
     case VarCompareValue(left.AsVariant, right.AsVariant) of

--- a/Source/Delphi.Mocks.Helpers.pas
+++ b/Source/Delphi.Mocks.Helpers.pas
@@ -338,7 +338,7 @@ end;
 
 class procedure TCustomValueComparerStore.RegisterCustomComparer<T>(const AComparer: TCustomValueComparer);
 begin
-  CustomComparers.Add(System.TypeInfo(T), AComparer);
+  CustomComparers.AddOrSetValue(System.TypeInfo(T), AComparer);
 end;
 
 class procedure TCustomValueComparerStore.UnRegisterCustomComparer<T>;

--- a/Source/Delphi.Mocks.WeakReference.pas
+++ b/Source/Delphi.Mocks.WeakReference.pas
@@ -39,12 +39,20 @@ uses
 
 type
   /// Implemented by our weak referenced object base class
+  {$IFOPT M+}
+    {$M-}
+    {$DEFINE ENABLED_M+}
+  {$ENDIF}
   IWeakReferenceableObject = interface
     ['{3D7F9CB5-27F2-41BF-8C5F-F6195C578755}']
     procedure AddWeakRef(value : Pointer);
     procedure RemoveWeakRef(value : Pointer);
     function GetRefCount : integer;
   end;
+  {$IFOPT M+}
+    {$M+}
+    {$UNDEF ENABLED_M+}
+  {$ENDIF}
 
   ///  This is our base class for any object that can have a weak reference to
   ///  it. It implements IInterface so the object can also be used just like


### PR DESCRIPTION
Added fix for comparing records using a custom comparer that can be registered for use with the TValueHelper.CompareValue routine. Although I added this with the intention of using it for records, I have added it at a higher level on the assumption that other types (or use cases) could benefit from custom comparisons. I'm thinking this could be good for objects when comparing the contents may be preferable?

I have also reverted a change made in e90fee5 where the logic {$M-} for IWeakReferenceableObject was removed. This change unfortunately borked the use of {$M+} at the project level for me. This has had no adverse effects on my use case but this change was made for a reason.