### PR TITLE
Call original method if behavior is not defined

### DIFF
--- a/Source/Delphi.Mocks.Helpers.pas
+++ b/Source/Delphi.Mocks.Helpers.pas
@@ -77,6 +77,10 @@ type
     function FindConstructor : TRttiMethod;
   end;
 
+  TRttiMethodHelper = class helper for TRttiMethod
+    function IsAbstract: Boolean;
+  end;
+
 
 function CompareValue(const Left, Right: TValue): Integer;
 function SameValue(const Left, Right: TValue): Boolean;
@@ -305,6 +309,16 @@ function TRttiTypeHelper.TryGetMethod(const AName: string; out AMethod: TRttiMet
 begin
   AMethod := GetMethod(AName);
   Result := Assigned(AMethod);
+end;
+
+{ TRttiMethodHelper }
+
+function TRttiMethodHelper.IsAbstract: Boolean;
+begin
+  if Self = nil then
+    Result := True
+  else
+    Result := PVmtMethodExEntry(Handle).Flags and (1 shl 7) <> 0;
 end;
 
 end.

--- a/Source/Delphi.Mocks.Interfaces.pas
+++ b/Source/Delphi.Mocks.Interfaces.pas
@@ -82,7 +82,7 @@ type
 
   IMethodData = interface
   ['{640BFB71-85C2-4ED4-A863-5AF6535BD2E8}']
-    procedure RecordHit(const Args: TArray<TValue>; const returnType : TRttiType; out Result: TValue);
+    procedure RecordHit(const Args: TArray<TValue>; const returnType : TRttiType; const method : TRttiMethod; out Result: TValue);
 
     //behaviors
     procedure WillReturnDefault(const returnValue : TValue);
@@ -114,6 +114,8 @@ type
 
     //Verification
     function Verify(var report : string) : boolean;
+
+    function BehaviorDefined: Boolean;
   end;
 
   IVerify = interface

--- a/Source/Delphi.Mocks.ObjectProxy.pas
+++ b/Source/Delphi.Mocks.ObjectProxy.pas
@@ -98,11 +98,20 @@ procedure TObjectProxy<T>.DoBefore(Instance: TObject; Method: TRttiMethod; const
 var
   vArgs: TArray<TValue>;
   i, l: Integer;
+  methodData : IMethodData;
+  pInfo : PTypeInfo;
 begin
   //don't intercept the TObject methods like BeforeDestruction etc.
   if Method.Parent.AsInstance.MetaclassType <> TObject then
   begin
-    DoInvoke := False; //don't call the actual method.
+    pInfo := TypeInfo(T);
+    methodData := GetMethodData(method.Name,pInfo.NameStr);
+
+    //Call the original (virtual) method if:
+    //-we are not a stub
+    //-we have not defined any behavior (of course we count hits)
+    //-the actual method is not an abstract method
+    DoInvoke := not (FIsStubOnly or methodData.BehaviorDefined or Method.IsAbstract);
 
     //Included instance as first argument because TExpectation.Match
     //deduces that the first argument is the object instance.

--- a/Source/Delphi.Mocks.Proxy.TypeInfo.pas
+++ b/Source/Delphi.Mocks.Proxy.TypeInfo.pas
@@ -333,7 +333,7 @@ begin
       //record actual behavior
       methodData := GetMethodData(method.Name,pInfo.NameStr);
       Assert(methodData <> nil);
-      methodData.RecordHit(Args,Method.ReturnType,Result);
+      methodData.RecordHit(Args,Method.ReturnType,Method,Result);
     end;
     TSetupMode.Behavior:
     begin

--- a/Source/Delphi.Mocks.Proxy.pas
+++ b/Source/Delphi.Mocks.Proxy.pas
@@ -71,7 +71,6 @@ type
     FMethodData             : TDictionary<string, IMethodData>;
     FBehaviorMustBeDefined  : Boolean;
     FAllowRedefineBehaviorDefinitions : Boolean;
-    FSetupMode              : TSetupMode;
     //behavior setup
     FNextBehavior           : TBehaviorType;
     FReturnValue            : TValue;
@@ -83,7 +82,6 @@ type
     FNextExpectation        : TExpectationType;
     FTimes                  : Cardinal;
     FBetween                : array[0..1] of Cardinal;
-    FIsStubOnly             : boolean;
 
     FQueryingInterface      : boolean;
     FQueryingInternalInterface : boolean;
@@ -106,6 +104,9 @@ type
     end;
 
   protected
+    FSetupMode              : TSetupMode;
+    FIsStubOnly             : boolean;
+
     procedure SetParentProxy(const AProxy : IProxy);
     function SupportsIInterface: Boolean;
 
@@ -441,7 +442,7 @@ begin
       methodData := GetMethodData(method.Name,pInfo.NameStr);
       Assert(methodData <> nil);
 
-      methodData.RecordHit(Args,Method.ReturnType,Result);
+      methodData.RecordHit(Args,Method.ReturnType,Method,Result);
     end;
     TSetupMode.Behavior:
     begin

--- a/Tests/Delphi.Mocks.Tests.MethodData.pas
+++ b/Tests/Delphi.Mocks.Tests.MethodData.pas
@@ -115,7 +115,7 @@ begin
   methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue1, nil);
   methodData.WillReturnWhen(TArray<TValue>.Create(someValue1), someValue2, nil);
 
-  methodData.RecordHit(TArray<TValue>.Create(someValue1), TrttiContext.Create.GetType(TypeInfo(integer)), outValue);
+  methodData.RecordHit(TArray<TValue>.Create(someValue1), TrttiContext.Create.GetType(TypeInfo(integer)), nil, outValue);
 
   Assert.AreEqual(someValue2.AsInteger, outValue.AsInteger );
 end;
@@ -127,7 +127,7 @@ var
   someValue   : TValue;
 begin
   methodData := TMethodData.Create('x', 'x', TSetupMethodDataParameters.Create(FALSE, FALSE, FALSE));
-  methodData.RecordHit(TArray<TValue>.Create(), nil, someValue);
+  methodData.RecordHit(TArray<TValue>.Create(), nil, nil, someValue);
   // no exception should be raised
   Assert.IsTrue(True);
 end;
@@ -141,7 +141,7 @@ begin
 
   Assert.WillRaise(procedure
   begin
-  methodData.RecordHit(TArray<TValue>.Create(), TRttiContext.Create.GetType(TypeInfo(Integer)), someValue);
+  methodData.RecordHit(TArray<TValue>.Create(), TRttiContext.Create.GetType(TypeInfo(Integer)), nil, someValue);
   end, EMockException);
 end;
 

--- a/Tests/Delphi.Mocks.Tests.ObjectProxy.pas
+++ b/Tests/Delphi.Mocks.Tests.ObjectProxy.pas
@@ -32,6 +32,7 @@ type
     procedure Run(value: Integer);virtual;abstract;
     procedure TestVarParam(var msg : string);virtual;abstract;
     procedure TestOutParam(out msg : string);virtual;abstract;
+    function VirtualMethod: Integer; virtual;
   end;
 
   {$M+}
@@ -62,6 +63,8 @@ type
     procedure TestOutParam;
     [Test]
     procedure TestVarParam;
+    [Test]
+    procedure MockNoBehaviorDefined;
   end;
   {$M-}
 
@@ -236,6 +239,16 @@ begin
   Assert.Pass;
 end;
 
+procedure TTestObjectProxy.MockNoBehaviorDefined;
+var
+  mock : TMock<TCommand>;
+begin
+  mock := TMock<TCommand>.Create;
+  mock.Setup.Expect.Once.When.VirtualMethod;
+  Assert.AreEqual(1, mock.Instance.VirtualMethod);
+  mock.Verify;
+end;
+
 procedure TTestObjectProxy.MockWithArgProcedureUsingOnce;
 var
   mock : TMock<TCommand>;
@@ -266,6 +279,13 @@ begin
   FCreateCalled := G_CREATE_CALLED_UNIQUE_ID;
 end;
 
+
+{ TCommand }
+
+function TCommand.VirtualMethod: Integer;
+begin
+  Result := 1;
+end;
 
 initialization
   TDUnitX.RegisterTestFixture(TTestObjectProxy);


### PR DESCRIPTION
In other languages only the (virtual) methods that are "setup" in the Mock are overriden. So, other virtual methods that are not "setup" keep the original behavior. This is usefull in mocking only parts of a class.