### PR TITLE
Raise exception if you try to mock a non-virtual method

### DIFF
--- a/Source/Delphi.Mocks.Proxy.pas
+++ b/Source/Delphi.Mocks.Proxy.pas
@@ -880,6 +880,10 @@ end;
 
 function TProxy<T>._Release: Integer;
 begin
+  if FSetupMode <> TSetupMode.None then begin
+    ClearSetupState;
+    raise EMockSetupException.Create('Setup called on non-virtual method');
+  end;
   result := inherited;
 end;
 

--- a/Tests/Delphi.Mocks.Tests.ObjectProxy.pas
+++ b/Tests/Delphi.Mocks.Tests.ObjectProxy.pas
@@ -33,6 +33,7 @@ type
     procedure TestVarParam(var msg : string);virtual;abstract;
     procedure TestOutParam(out msg : string);virtual;abstract;
     function VirtualMethod: Integer; virtual;
+    function NonVirtualMethod: Integer;
   end;
 
   {$M+}
@@ -65,6 +66,8 @@ type
     procedure TestVarParam;
     [Test]
     procedure MockNoBehaviorDefined;
+    [Test]
+    procedure WillRaiseMockNonVirtualMethod;
   end;
   {$M-}
 
@@ -249,6 +252,15 @@ begin
   mock.Verify;
 end;
 
+procedure TTestObjectProxy.WillRaiseMockNonVirtualMethod;
+var
+  mock : TMock<TCommand>;
+begin
+  mock := TMock<TCommand>.Create;
+  Assert.WillRaise(procedure begin mock.Setup.Expect.Once.When.NonVirtualMethod; end);
+  Assert.WillRaise(procedure begin mock.Setup.WillReturn(2).When.NonVirtualMethod; end);
+end;
+
 procedure TTestObjectProxy.MockWithArgProcedureUsingOnce;
 var
   mock : TMock<TCommand>;
@@ -281,6 +293,11 @@ end;
 
 
 { TCommand }
+
+function TCommand.NonVirtualMethod: Integer;
+begin
+  Result := 1;
+end;
 
 function TCommand.VirtualMethod: Integer;
 begin


### PR DESCRIPTION
This is a solution for "No warning or error reported for non-virtual method calls. #47"