### PR TITLE
Reset calls and clear expectations

### DIFF
--- a/Source/Delphi.Mocks.Expectation.pas
+++ b/Source/Delphi.Mocks.Expectation.pas
@@ -59,6 +59,7 @@ type
     function Report : string;
     function ArgsToString : string;
     procedure CopyArgs(const Args: TArray<TValue>);
+    procedure ResetCalls;
     constructor Create(const AMethodName : string);
     constructor CreateWhen(const AMethodName : string; const Args: TArray<TValue>; const matchers : TArray<IMatcher>);
   public
@@ -407,6 +408,12 @@ begin
     result := 'Expectation [ ' + result + ' ] was not met.';
   end;
 
+end;
+
+procedure TExpectation.ResetCalls;
+begin
+  FHitCount := 0;
+  CheckExpectationMet;
 end;
 
 end.

--- a/Source/Delphi.Mocks.Interfaces.pas
+++ b/Source/Delphi.Mocks.Interfaces.pas
@@ -112,6 +112,7 @@ type
     procedure Before(const ABeforeMethodName : string);
     procedure AfterWhen(const AAfterMethodName : string;const Args : TArray<TValue>; const matchers : TArray<IMatcher>);
     procedure After(const AAfterMethodName : string);
+    procedure ClearExpectations;
 
     //Verification
     function Verify(var report : string) : boolean;

--- a/Source/Delphi.Mocks.Interfaces.pas
+++ b/Source/Delphi.Mocks.Interfaces.pas
@@ -74,6 +74,7 @@ type
     function GetExpectationMet : boolean;
     function Match(const Args : TArray<TValue>) : boolean;
     procedure RecordHit;
+    procedure ResetCalls;
     function Report : string;
     property ExpectationType : TExpectationType read GetExpectationType;
     property ExpectationMet : boolean read GetExpectationMet;
@@ -114,6 +115,7 @@ type
 
     //Verification
     function Verify(var report : string) : boolean;
+    procedure ResetCalls;
 
     function FindBestBehavior(const Args: TArray<TValue>) : IBehavior;
   end;
@@ -123,6 +125,7 @@ type
     procedure Verify(const message : string = '');
     procedure VerifyAll(const message : string = '');
     function CheckExpectations: string;
+    procedure ResetCalls;
   end;
 
 implementation

--- a/Source/Delphi.Mocks.MethodData.pas
+++ b/Source/Delphi.Mocks.MethodData.pas
@@ -96,6 +96,7 @@ type
     procedure After(const AAfterMethodName : string);
 
     function Verify(var report : string) : boolean;
+    procedure ResetCalls;
   public
     constructor Create(const ATypeName : string; const AMethodName : string; const ASetupParameters: TSetupMethodDataParameters; const AAutoMocker : IAutoMock = nil);
     destructor Destroy;override;
@@ -529,6 +530,16 @@ begin
 
   if returnType <> nil then
     Result := returnValue;
+end;
+
+procedure TMethodData.ResetCalls;
+var
+  expectation : IExpectation;
+begin
+  for expectation in FExpectations do
+  begin
+    expectation.ResetCalls;
+  end;
 end;
 
 procedure TMethodData.StubNoBehaviourRecordHit(const Args: TArray<TValue>; const AExpectationHitCtr : Integer; const returnType: TRttiType; out Result: TValue);

--- a/Source/Delphi.Mocks.MethodData.pas
+++ b/Source/Delphi.Mocks.MethodData.pas
@@ -97,6 +97,7 @@ type
 
     function Verify(var report : string) : boolean;
     procedure ResetCalls;
+    procedure ClearExpectations;
   public
     constructor Create(const ATypeName : string; const AMethodName : string; const ASetupParameters: TSetupMethodDataParameters; const AAutoMocker : IAutoMock = nil);
     destructor Destroy;override;
@@ -118,6 +119,11 @@ uses
 
 { TMethodData }
 
+
+procedure TMethodData.ClearExpectations;
+begin
+  FExpectations.Clear;
+end;
 
 constructor TMethodData.Create(const ATypeName : string; const AMethodName : string; const ASetupParameters: TSetupMethodDataParameters; const AAutoMocker : IAutoMock = nil);
 begin

--- a/Source/Delphi.Mocks.Proxy.TypeInfo.pas
+++ b/Source/Delphi.Mocks.Proxy.TypeInfo.pas
@@ -111,6 +111,7 @@ type
     //IVerify
     procedure Verify(const message : string = '');
     procedure VerifyAll(const message : string = '');
+    procedure ResetCalls;
 
     function CheckExpectations: string;
 
@@ -542,6 +543,16 @@ begin
       Exit;
   finally
     FQueryingInterface := False;
+  end;
+end;
+
+procedure TProxy.ResetCalls;
+var
+  methodData : IMethodData;
+begin
+  for methodData in FMethodData.Values do
+  begin
+    methodData.ResetCalls;
   end;
 end;
 

--- a/Source/Delphi.Mocks.Proxy.TypeInfo.pas
+++ b/Source/Delphi.Mocks.Proxy.TypeInfo.pas
@@ -772,7 +772,7 @@ var
   interfaceV : IVerify;
 begin
   //Verify ourselves.
-  Verify;
+  Verify(message);
 
   //Now verify all our children.
   for proxy in FInterfaceProxies.Values.ToArray do

--- a/Source/Delphi.Mocks.Proxy.pas
+++ b/Source/Delphi.Mocks.Proxy.pas
@@ -958,7 +958,7 @@ var
   interfaceV : IVerify;
 begin
   //Verify ourselves.
-  Verify;
+  Verify(message);
 
   //Now verify all our children.
   for proxy in FInterfaceProxies.Values.ToArray do

--- a/Source/Delphi.Mocks.Proxy.pas
+++ b/Source/Delphi.Mocks.Proxy.pas
@@ -192,6 +192,8 @@ type
 
     function After(const AMethodName : string) : IWhen<T>;overload;
     procedure After(const AMethodName : string; const AAfterMethodName : string);overload;
+
+    procedure Clear;
   public
     constructor Create(const AAutoMocker : IAutoMock = nil; const AIsStubOnly : boolean = false); virtual;
     destructor Destroy; override;
@@ -370,6 +372,16 @@ begin
         Result := Result + #13#10;
       Result := Result + report ;
     end;
+  end;
+end;
+
+procedure TProxy<T>.Clear;
+var
+  methodData : IMethodData;
+begin
+  for methodData in FMethodData.Values do
+  begin
+    methodData.ClearExpectations;
   end;
 end;
 

--- a/Source/Delphi.Mocks.Proxy.pas
+++ b/Source/Delphi.Mocks.Proxy.pas
@@ -157,6 +157,7 @@ type
     //IVerify
     procedure Verify(const message : string = '');
     procedure VerifyAll(const message : string = '');
+    procedure ResetCalls;
 
     function CheckExpectations: string;
 
@@ -691,6 +692,16 @@ begin
       Exit;
   finally
     FQueryingInterface := False;
+  end;
+end;
+
+procedure TProxy<T>.ResetCalls;
+var
+  methodData : IMethodData;
+begin
+  for methodData in FMethodData.Values do
+  begin
+    methodData.ResetCalls;
   end;
 end;
 

--- a/Source/Delphi.Mocks.pas
+++ b/Source/Delphi.Mocks.pas
@@ -70,6 +70,8 @@ type
 
     function After(const AMethodName : string) : IWhen<T>;overload;
     procedure After(const AMethodName : string; const AAfterMethodName : string);overload;
+
+    procedure Clear;
   end;
 
   IWhen<T> = interface

--- a/Source/Delphi.Mocks.pas
+++ b/Source/Delphi.Mocks.pas
@@ -209,6 +209,7 @@ type
     procedure Verify(const message : string = ''); overload;
     procedure Verify<I : IInterface>(const message : string = ''); overload;
     procedure VerifyAll(const message : string = '');
+    procedure ResetCalls;
 
     function CheckExpectations: string;
     procedure Implement<I : IInterface>; overload;
@@ -460,6 +461,18 @@ begin
   CheckCreated;
 
   result := TValue.From<I>(Self.Instance<I>);
+end;
+
+procedure TMock<T>.ResetCalls;
+var
+  interfaceV : IVerify;
+begin
+  CheckCreated;
+
+  if Supports(FProxy.Setup, IVerify, interfaceV) then
+    interfaceV.ResetCalls
+  else
+    raise EMockException.Create('Could not cast Setup to IVerify interface!');
 end;
 
 function TMock<T>.Setup: IMockSetup<T>;

--- a/Tests/Delphi.Mocks.Tests.Expectations.pas
+++ b/Tests/Delphi.Mocks.Tests.Expectations.pas
@@ -39,6 +39,7 @@ type
     //ExpectationMet after record hit tests
     procedure ExpectationMet_With_OnceWhen_CalledOnce;
     procedure ExpectationNotMet_With_OnceWhen_CalledNever;
+    procedure ExpectationNotMet_With_OnceWhen_CalledOnceAndResetCalls;
 
     procedure ExpectationMet_With_Never_CalledNever;
     procedure ExpectationNotMet_With_Never_CalledOnce;
@@ -273,6 +274,17 @@ begin
   Assert.IsFalse(expectation.ExpectationMet, 'Exception met for OnceWhen being not called');
 end;
 
+procedure TTestExpectations.ExpectationNotMet_With_OnceWhen_CalledOnceAndResetCalls;
+var
+  expectation : IExpectation;
+begin
+  expectation := TExpectation.CreateOnceWhen('', nil, FMatchers);
+
+  expectation.RecordHit;
+  Assert.IsTrue(expectation.ExpectationMet, 'Exception not met for OnceWhen being called once');
+  expectation.ResetCalls;
+  Assert.IsFalse(expectation.ExpectationMet, 'Exception not met for OnceWhen being called once, after ResetCalls');
+end;
 
 procedure TTestExpectations.ExpectationNotMet_With_Between_1to4_CalledNever;
 var

--- a/Tests/Delphi.Mocks.Tests.Proxy.pas
+++ b/Tests/Delphi.Mocks.Tests.Proxy.pas
@@ -17,6 +17,8 @@ type
     procedure Expectation_Before_Verifies_To_True_When_Prior_Method_Called_Atleast_Once;
     [Test]
     procedure VerifyAllRespectsMessage;
+    [Test]
+    procedure ResetCallsWorks;
   end;
   {$M-}
 
@@ -39,6 +41,18 @@ type
 procedure TTestMock.Expectation_Before_Verifies_To_True_When_Prior_Method_Called_Atleast_Once;
 begin
   Assert.NotImplemented;
+end;
+
+procedure TTestMock.ResetCallsWorks;
+var
+  m: TMock<TSimpleClass>;
+begin
+  m := TMock<TSimpleClass>.Create;
+  m.Setup.Expect.Once.When.DoTest;
+  m.Instance.DoTest;
+  Assert.WillNotRaise(procedure begin m.VerifyAll() end);
+  m.ResetCalls;
+  Assert.WillRaise(procedure begin m.VerifyAll() end, EMockVerificationException);
 end;
 
 procedure TTestMock.VerifyAllRespectsMessage;

--- a/Tests/Delphi.Mocks.Tests.Proxy.pas
+++ b/Tests/Delphi.Mocks.Tests.Proxy.pas
@@ -19,6 +19,8 @@ type
     procedure VerifyAllRespectsMessage;
     [Test]
     procedure ResetCallsWorks;
+    [Test]
+    procedure ClearExpectationsWorks;
   end;
   {$M-}
 
@@ -37,6 +39,17 @@ type
   end;
 
 { TTestMock }
+
+procedure TTestMock.ClearExpectationsWorks;
+var
+  m: TMock<TSimpleClass>;
+begin
+  m := TMock<TSimpleClass>.Create;
+  m.Setup.Expect.Once.When.DoTest;
+  Assert.WillRaise(procedure begin m.VerifyAll() end, EMockVerificationException);
+  m.Setup.Expect.Clear;
+  Assert.WillNotRaise(procedure begin m.VerifyAll() end);
+end;
 
 procedure TTestMock.Expectation_Before_Verifies_To_True_When_Prior_Method_Called_Atleast_Once;
 begin

--- a/Tests/Delphi.Mocks.Tests.Proxy.pas
+++ b/Tests/Delphi.Mocks.Tests.Proxy.pas
@@ -15,6 +15,8 @@ type
   published
     [Test, Ignore]
     procedure Expectation_Before_Verifies_To_True_When_Prior_Method_Called_Atleast_Once;
+    [Test]
+    procedure VerifyAllRespectsMessage;
   end;
   {$M-}
 
@@ -26,13 +28,34 @@ uses
   Delphi.Mocks.MethodData,
   classes;
 
-
+type
+  TSimpleClass = class
+  public
+    procedure DoTest; virtual; abstract;
+  end;
 
 { TTestMock }
 
 procedure TTestMock.Expectation_Before_Verifies_To_True_When_Prior_Method_Called_Atleast_Once;
 begin
   Assert.NotImplemented;
+end;
+
+procedure TTestMock.VerifyAllRespectsMessage;
+var
+  m: TMock<TSimpleClass>;
+begin
+  m := TMock<TSimpleClass>.Create;
+  m.Setup.Expect.Once.When.DoTest;
+  try
+    m.VerifyAll('test');
+  except
+    on E: EMockVerificationException do begin
+      Assert.IsTrue(E.Message.StartsWith('test'));
+      Exit;
+    end;
+  end;
+  Assert.Fail('Verifyall does not respect message');
 end;
 
 initialization


### PR DESCRIPTION
I have introduced two new methods to re-use the same mock in a flow where you redefine the behavior (and expectations) several times in one test.

**TMock<T>.ResetCalls**
This is used to reset the recordhit on all methods in the mock. I'm not sure that this method should be moved to `TMock<T>.Setup.Expect.ResetCalls`.

**TMock<T>.Setup.Expect.Clear**
This is used to remove all defined expectations on the mock.