### PR TITLE
Several fixes and extentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,54 @@
 # Delphi Mocks
 
-Delphi Mocks is a simple mocking framework for Delphi XE2 or later. It makes use of RTTI features that are only available in Delphi XE2.
+Delphi Mocks is a simple mocking framework for Delphi XE2 or later. It makes use of RTTI features that are only available in Delphi XE2. See the example at the bottom of the space for a complete explanation.
+
+# Parameter matching
+
+To match expectations or behavior there is extended parameter matching.
+
+```Pascal
+    function IsAny<T>() : T ;
+    function Matches<T>(const predicate: TPredicate<T>) : T;
+    function IsNotNil<T> : T; overload;
+    function IsNotNil<T>(const comparer: IEqualityComparer<T>) : T; overload;
+    function IsEqualTo<T>(const value : T) : T; overload;
+    function IsEqualTo<T>(const value : T; const comparer: IEqualityComparer<T>) : T; overload;
+    function IsInRange<T>(const fromValue : T; const toValue : T) : T;
+    function IsIn<T>(const values : TArray<T>) : T; overload;
+    function IsIn<T>(const values : TArray<T>; const comparer: IEqualityComparer<T>) : T; overload;
+    function IsIn<T>(const values : IEnumerable<T>) : T; overload;
+    function IsIn<T>(const values : IEnumerable<T>; const comparer: IEqualityComparer<T>) : T; overload;
+    function IsNotIn<T>(const values : TArray<T>) : T; overload;
+    function IsNotIn<T>(const values : TArray<T>; const comparer: IEqualityComparer<T>) : T; overload;
+    function IsNotIn<T>(const values : IEnumerable<T>) : T; overload;
+    function IsNotIn<T>(const values : IEnumerable<T>; const comparer: IEqualityComparer<T>) : T; overload;
+    function IsRegex(const regex : string; const options : TRegExOptions = []) : string;
+    function AreSamePropertiesThat<T>(const Value: T): T;
+    function AreSameFieldsThat<T>(const Value: T): T;
+    function AreSameFieldsAndPropertiedThat<T>(const Value: T): T;
+```
+
+Usage is easy:
+
+```Pascal
+  mock.Setup.Expect.Once.When.SimpleMethod(It0.IsAny<Integer>, It1.IsAny<String>);
+  mock.Setup.WillReturn(3).When.SimpleFunction(It0.IsEqualTo<String>('hello'));
+```
+
+## Class matching
+Some more attention should be payed for matching classes. Usage of `.IsAny<TMyClass>` will not work as might be expected, because `nil` (which is the default return value of `IsAny<T>`) is always a good match. Therefore the following setup will fail on the second line, because the framework will think that there is already behavior defined (in the first line).
+
+```Pascal
+  mock.Setup.Expect.Never.When.ExtendedMethod(It0.IsAny<TMyClass>);
+  mock.Setup.Expect.Never.When.ExtendedMethod(It0.IsAny<TMyOtherClass>);
+```
+
+This can easily be solved by using `.IsNotNil<TMyClass>`:
+
+```Pascal
+  mock.Setup.Expect.Never.When.ExtendedMethod(It0.IsNotNil<TMyClass>);
+  mock.Setup.Expect.Never.When.ExtendedMethod(It0.IsNotNil<TMyOtherClass>);
+```
 
 # Example
 

--- a/Source/Delphi.Mocks.Behavior.pas
+++ b/Source/Delphi.Mocks.Behavior.pas
@@ -74,11 +74,11 @@ var
 begin
   //Note : Args[0] is the Self Ptr for the proxy, we do not want to keep
   //a reference to it so it is ignored here.
-  l := Length(args);
-  if l > 0 then
+  l := Length(Args) -1;
+  if l > 0  then
   begin
     SetLength(FArgs,l);
-    CopyArray(@FArgs[0],@args[0],TypeInfo(TValue),l);
+    CopyArray(@FArgs[0],@args[1],TypeInfo(TValue),l);
   end;
 end;
 
@@ -178,11 +178,12 @@ function TBehavior.Match(const Args: TArray<TValue>): Boolean;
     i : integer;
   begin
     result := False;
-    if Length(Args) <> (Length(FArgs)) then
+    if Length(Args) <> (Length(FArgs) + 1 ) then
       exit;
-    for i := 0 to Length(args) -1 do
+    //start at 1 as we don't care about matching the first arg (self)
+    for i := 1 to Length(args) -1 do
     begin
-      if not FArgs[i].Equals(args[i]) then
+      if not FArgs[i -1].Equals(args[i]) then
         exit;
     end;
     result := True;
@@ -204,24 +205,23 @@ function TBehavior.Match(const Args: TArray<TValue>): Boolean;
 begin
   result := False;
 
-  if (Length(FMatchers) > 0) and (Length(Args) = (Length(FMatchers) + 1)) then
+  if Length(FMatchers) > 0 then
   begin
     result := MatchWithMatchers;
-    exit;
-  end;
-
-  case FBehaviorType of
-    WillReturn      : result := MatchArgs;
-    ReturnDefault   : result := True;
-    WillRaise       :
-    begin
-      result := MatchArgs;
-      if FExceptClass <> nil then
-        raise FExceptClass.Create('Raised by Mock');
+  end else begin
+    case FBehaviorType of
+      WillReturn      : result := MatchArgs;
+      ReturnDefault   : result := True;
+      WillRaise       :
+      begin
+        result := MatchArgs;
+        if FExceptClass <> nil then
+          raise FExceptClass.Create('Raised by Mock');
+      end;
+      WillRaiseAlways : result := True;
+      WillExecuteWhen : result := MatchArgs;
+      WillExecute     : result := True;
     end;
-    WillRaiseAlways : result := True;
-    WillExecuteWhen : result := MatchArgs;
-    WillExecute     : result := True;
   end;
 end;
 

--- a/Source/Delphi.Mocks.ParamMatcher.pas
+++ b/Source/Delphi.Mocks.ParamMatcher.pas
@@ -90,7 +90,14 @@ end;
 
 function TMatcher<T>.Match(const value: TValue): boolean;
 begin
-  result := FPredicate(value.AsType<T>);
+  try
+    result := FPredicate(value.AsType<T>);
+  except
+    on E: EInvalidCast do
+      Result := False
+    else
+      raise;
+  end;
 end;
 
 class constructor TMatcherFactory.Create;

--- a/Tests/Delphi.Mocks.Examples.Matchers.pas
+++ b/Tests/Delphi.Mocks.Examples.Matchers.pas
@@ -17,6 +17,10 @@ type
     property PropertyToTest: Integer read FPropertyToTest write FPropertyToTest;
   end;
 
+  TAnotherObject = class(TObjectToTest);
+
+  TAndAnotherObject = class(TObjectToTest);
+
   TRecordToTest = record
   private
     internalValue: String;
@@ -72,6 +76,12 @@ type
     procedure Record_with_equality_comparer;
     [Test]
     procedure Record_with_operator_overloaded_comparer;
+  end;
+
+  [TestFixture]
+  TItClassTests = class
+    [Test]
+    procedure Class_descendant_matches_on_exact_type;
   end;
 
 implementation
@@ -257,9 +267,38 @@ begin
   Assert.IsTrue(LMatchers[3].Match(TValue.From<TRecordToTest>('test3')));
 end;
 
+{ TItClassTests }
+
+procedure TItClassTests.Class_descendant_matches_on_exact_type;
+var
+  LMatchers: TArray<IMatcher>;
+  LAnotherObject: TAnotherObject;
+  LAndAnotherObject: TAndAnotherObject;
+begin
+  Assert.AreEqual(0, Length(LMatchers));
+
+  It(0).IsAny<TAnotherObject>();
+  It(1).IsAny<TAndAnotherObject>();
+
+  LMatchers := TMatcherFactory.GetMatchers();
+
+  LAnotherObject := TAnotherObject.Create;
+  LAndAnotherObject := TAndAnotherObject.Create;
+  try
+    Assert.IsTrue(LMatchers[0].Match(TValue.From<TAnotherObject>(LAnotherObject)));
+    Assert.IsTrue(LMatchers[1].Match(TValue.From<TAndAnotherObject>(LAndAnotherObject)));
+
+    Assert.IsFalse(LMatchers[1].Match(TValue.From<TAndAnotherObject>(TAndAnotherObject(LAnotherObject))));
+  finally
+    LAnotherObject.Free;
+    LAndAnotherObject.Free;
+  end;
+end;
+
 initialization
   TDUnitX.RegisterTestFixture(TExample_MatchersTests);
   TDUnitX.RegisterTestFixture(TItRecTests);
+  TDUnitX.RegisterTestFixture(TItClassTests);
 
 end.
 


### PR DESCRIPTION
Parameter matching sometimes fails with objects which are not compatible. This mainly happens if the signature of a method expects a baseclass, but the matcher cannot cast the parameter passed.

Now also TBehavior and TExpectations works the same and I slightly updated the documentation.