### PR TITLE
Fix memory leak in TMock<T>, TStub<T>, and TAutoMockContainer

### DIFF
--- a/Source/Delphi.Mocks.Helpers.pas
+++ b/Source/Delphi.Mocks.Helpers.pas
@@ -373,4 +373,10 @@ begin
   Result := DispatchKind = dkVtable;
 end;
 
+initialization
+  Context := TRttiContext.Create;
+
+finalization
+  Context.Free;
+
 end.

--- a/Source/Delphi.Mocks.pas
+++ b/Source/Delphi.Mocks.pas
@@ -359,7 +359,11 @@ var
   pInfo : PTypeInfo;
 begin
   //Make sure that we start off with a clean mock
-  FillChar(Result, SizeOf(Result), 0);
+  //NOTE: Do NOT use FillChar here! Due to return value optimization,
+  //Result may be the same memory as the caller's variable, and FillChar
+  //would bypass finalization of managed fields (causing memory leaks).
+  //Use Default() which properly handles managed types.
+  Result := Default(TMock<T>);
 
   //By default we don't auto mock TMock<T>. It changes when TAutoMock is used.
   Result.FAutomocker := AAutoMock;
@@ -577,8 +581,11 @@ var
   proxy : IInterface;
   pInfo : PTypeInfo;
 begin
-  //Make sure that we start off with a clean mock
-  FillChar(Result, SizeOf(Result), 0);
+  //Make sure that we start off with a clean stub
+  //NOTE: Do NOT use FillChar here! Due to return value optimization,
+  //Result may be the same memory as the caller's variable, and FillChar
+  //would bypass finalization of managed fields (causing memory leaks).
+  Result := Default(TStub<T>);
 
   //By default we don't auto mock TMock<T>. It changes when TAutoMock is used.
   Result.FAutomocker := nil;
@@ -659,7 +666,10 @@ end;
 
 class function TAutoMockContainer.Create: TAutoMockContainer;
 begin
-  FillChar(Result, SizeOf(Result), 0);
+  //NOTE: Do NOT use FillChar here! Due to return value optimization,
+  //Result may be the same memory as the caller's variable, and FillChar
+  //would bypass finalization of managed fields (causing memory leaks).
+  Result := Default(TAutoMockContainer);
 
   Result.FAutoMocker := TAutoMock.Create;
 end;


### PR DESCRIPTION
## Summary
- Replace `FillChar(Result, SizeOf(Result), 0)` with `Result := Default(T)` in record class functions
- Add `TRttiContext` initialization/finalization to `Delphi.Mocks.Helpers.pas`

## Problem
When reassigning `TMock<T>` or `TStub<T>` record variables, the previous mock was not being properly released, causing memory leaks.

**Root Cause**: Due to Delphi's return value optimization (RVO), the `Result` variable in a class function may be the same memory location as the caller's variable. Using `FillChar(Result, ...)` to initialize the record bypasses the compiler-generated finalization of managed fields (interface references), causing the previous interface reference to be overwritten without calling `_Release`.

## Example that leaked before this fix:
```pascal
var
  Mock: TMock<IMyInterface>;
begin
  Mock := TMock<IMyInterface>.Create;  // First mock created
  Mock.Setup.WillReturn(True).When.SomeMethod;
  
  Mock := TMock<IMyInterface>.Create;  // Second mock - first mock LEAKED!
  Mock.Setup.WillReturn(False).When.SomeMethod;
end;  // Only second mock is released
```

## The Fix
Replace:
```pascal
FillChar(Result, SizeOf(Result), 0);
```

With:
```pascal
Result := Default(TMock<T>);
```

The `Default()` intrinsic properly handles managed types and allows the compiler to insert finalization code for the old value.

## Testing
Tested with DUnitX. Before fix: memory leaks reported. After fix: no memory leaks.
